### PR TITLE
Timeseries are passed as list (analogous to markovprocess estimators)

### DIFF
--- a/sktime/covariance/online_covariance.py
+++ b/sktime/covariance/online_covariance.py
@@ -16,18 +16,18 @@ __author__ = 'paul, nueske, marscher, clonker'
 def ensure_timeseries_data(input_data):
     if not isinstance(input_data, list):
         if not isinstance(input_data, np.ndarray):
-            raise ValueError(input_data)
+            raise ValueError('input data can not be converted to a list of arrays')
         elif isinstance(input_data, np.ndarray):
             if input_data.dtype not in (np.float32, np.float64):
-                raise ValueError
+                raise ValueError('only float and double dtype is supported')
             return [input_data]
     else:
         for i, x in enumerate(input_data):
             if not isinstance(x, np.ndarray):
-                raise ValueError()
+                raise ValueError(f'element {i} of given input data list is not an array.')
             else:
                 if x.dtype not in (np.float32, np.float64):
-                    raise ValueError
+                    raise ValueError('only float and double dtype is supported')
                 input_data[i] = x
     return input_data
 
@@ -155,10 +155,6 @@ class OnlineCovariance(Estimator):
         else:
             self.lagtime = lagtime
         assert lagtime is not None
-
-        assert isinstance(data, list)
-        assert all(isinstance(e, np.ndarray) for e in data)
-        assert all(e.dtype in (np.float32, np.float64) for e in data)
 
         lazy_weights = False
         wsplit = itertools.repeat(None)

--- a/sktime/covariance/online_covariance.py
+++ b/sktime/covariance/online_covariance.py
@@ -1,13 +1,33 @@
 import numpy as np
-from numpy.linalg import eig
+from scipy.linalg import eig
 
 from sktime.base import Estimator, Model
+from sktime.data.util import timeshifted_split
 from .util.running_moments import running_covar as running_covar
 from sktime.numeric.eigen import spd_inv_split, sort_by_norm
 
 __all__ = ['OnlineCovariance']
 
 __author__ = 'paul, nueske, marscher, clonker'
+
+
+def ensure_timeseries_data(input_data):
+    if not isinstance(input_data, list):
+        if not isinstance(input_data, np.ndarray):
+            raise ValueError(input_data)
+        elif isinstance(input_data, np.ndarray):
+            if input_data.dtype not in (np.float32, np.float64):
+                raise ValueError
+            return [input_data]
+    else:
+        for i, x in enumerate(input_data):
+            if not isinstance(x, np.ndarray):
+                raise ValueError()
+            else:
+                if x.dtype not in (np.float32, np.float64):
+                    raise ValueError
+                input_data[i] = x
+    return input_data
 
 
 class OnlineCovarianceModel(Model):
@@ -17,6 +37,7 @@ class OnlineCovarianceModel(Model):
         self._cov_tt = None
         self._mean_0 = None
         self._mean_t = None
+        self._bessel = None
 
     @property
     def cov_00(self):
@@ -37,6 +58,10 @@ class OnlineCovarianceModel(Model):
     @property
     def mean_t(self):
         return self._mean_t
+
+    @property
+    def bessel(self):
+        return self._bessel
 
 
 class OnlineCovariance(Estimator):
@@ -67,9 +92,8 @@ class OnlineCovariance(Estimator):
     diag_only: bool
         If True, the computation is restricted to the diagonal entries (autocorrelations) only.
     """
-    def __init__(self, compute_c00=True, compute_c0t=False, compute_ctt=False, remove_data_mean=False,
+    def __init__(self, lagtime=None, compute_c00=True, compute_c0t=False, compute_ctt=False, remove_data_mean=False,
                  reversible=False, bessel=True, sparse_mode='auto', ncov=5, diag_only=False, model=None):
-        super(OnlineCovariance, self).__init__(model=model)
 
         if diag_only and sparse_mode is not 'dense':
             if sparse_mode is 'sparse':
@@ -78,6 +102,11 @@ class OnlineCovariance(Estimator):
                               'mode.')
             sparse_mode = 'dense'
 
+        if (compute_c0t or compute_ctt) and lagtime is None:
+            raise ValueError('lagtime parameter mandatory due to requested covariance matrices.')
+
+        super(OnlineCovariance, self).__init__(model=model)
+        self.lagtime = lagtime
         self.compute_c00 = compute_c00
         self.compute_c0t = compute_c0t
         self.compute_ctt = compute_ctt
@@ -100,45 +129,54 @@ class OnlineCovariance(Estimator):
     def is_lagged(self) -> bool:
         return self.compute_c0t or self.compute_ctt
 
-    def fit(self, data, weights=None, n_splits=None, column_selection=None):
+    def fit(self, data, lagtime=None, weights=None, n_splits=None, column_selection=None):
         """
          column_selection: ndarray(k, dtype=int) or None
          Indices of those columns that are to be computed. If None, all columns are computed.
-        :param data:
-        :param weights:
+        :param data: list of sequences (n elements)
+        :param weights: list of weight arrays (n elements) or array (shape
         :param n_splits:
         :param column_selection:
         :return:
         """
+        # TODO: constistent dtype
+        data = ensure_timeseries_data(data)
+
         self._rc.clear()
+
         if n_splits is None:
-            if self.is_lagged:
-                dlen = len(data[0])
-            else:
-                dlen = len(data)
+            dlen = min(len(d) for d in data)
             n_splits = int(dlen // 100 if dlen >= 1e4 else 1)
-        if self.is_lagged:
-            x, x_lagged = data
+
+        if lagtime is None:
+            lagtime = self.lagtime
         else:
-            x, x_lagged = data, np.empty((0,))
+            self.lagtime = lagtime
+        assert lagtime is not None
 
-        x, x_lagged = np.asarray_chkfinite(x), np.asarray_chkfinite(x_lagged)
+        assert isinstance(data, list)
+        assert all(isinstance(e, np.ndarray) for e in data)
+        assert all(e.dtype in (np.float32, np.float64) for e in data)
 
-        assert len(x_lagged) == 0 or len(x) == len(x_lagged), f"Expected data and time lagged data of equal length " \
-            f"but got {len(x)} != {len(x_lagged)}"
+        if weights is not None:
+            if len(np.atleast_1d(weights)) != len(data[0]):
+                raise ValueError(
+                    "Weights have incompatible shape "
+                    f"(#weights={len(weights) if weights is not None else None} != {len(data[0])}=#frames.")
+            wsplit = np.array_split(weights, n_splits) if weights is not None else [None] * n_splits
+        else:
+            import itertools
+            wsplit = itertools.repeat(None)
 
-        if weights is not None and len(np.atleast_1d(weights)) != len(x):
-            raise ValueError(f"Weights have incompatible shape "
-                             f"(#weights={len(weights) if weights is not None else None} != {len(x)}=#frames.")
-        wsplit = np.array_split(weights, n_splits) if weights is not None else [None] * n_splits
-
-        for x_batch, y_batch, w in zip(np.array_split(x, n_splits), np.array_split(x_lagged, n_splits), wsplit):
-            assert len(x_batch) == len(y_batch) or (not self.is_lagged and len(y_batch) == 0)
-            assert w is None or len(x_batch) == len(w)
-            if not self.is_lagged:
-                self.partial_fit(x_batch, column_selection=column_selection, weights=w)
-            else:
-                self.partial_fit((x_batch, y_batch), column_selection=column_selection, weights=w)
+        if self.is_lagged:
+            for (x, y), w in zip(timeshifted_split(data, lagtime=lagtime, n_splits=n_splits), wsplit):
+                # TODO: can weights be shorter than actual data
+                if isinstance(w, np.ndarray):
+                    w = w[:len(x)]
+                self.partial_fit((x, y), weights=w, column_selection=column_selection)
+        else:
+            for x in data:
+                self.partial_fit(x, weights=weights, column_selection=column_selection)
 
         return self
 
@@ -154,12 +192,13 @@ class OnlineCovariance(Estimator):
         if self.is_lagged:
             x, y = data
         else:
-            x, y = data, np.empty((0,))
-        if weights is not None and len(x) != len(np.atleast_1d(weights)):
-            raise ValueError(f"Weights have incompatible size (weights length "
-                             f"{len(weights) if weights is not None else None}, data length {len(x)})")
+            x, y = data, None
+        # todo: weights can be scalar, None or vector.
+        #if weights is not None and len(x) != len(np.atleast_1d(weights)):
+        #    raise ValueError(f"Weights have incompatible size (weights length "
+        #                     f"{len(weights) if weights is not None else None}, data length {len(x)})")
         try:
-            self._rc.add(x, y if len(y) > 0 else None, column_selection=column_selection, weights=weights)
+            self._rc.add(x, y, column_selection=column_selection, weights=weights)
         except MemoryError:
             raise MemoryError('Covariance matrix does not fit into memory. '
                               'Input is too high-dimensional ({} dimensions). '.format(x.shape[1]))
@@ -177,6 +216,7 @@ class OnlineCovariance(Estimator):
             self._model._mean_0 = self._rc.mean_X()
         if self.compute_ctt or self.compute_c0t:
             self._model._mean_t = self._rc.mean_Y()
+        self._model._bessel = self.bessel
 
     def fetch_model(self) -> OnlineCovarianceModel:
         self._update_model()
@@ -203,6 +243,7 @@ class KoopmanEstimator(Estimator):
 
     def fit(self, data, y=None):
         self._cov.fit(data)
+        self.fetch_model()  # pre-compute Koopman operator
         return self
 
     def partial_fit(self, data):

--- a/sktime/covariance/util/running_moments.py
+++ b/sktime/covariance/util/running_moments.py
@@ -1,6 +1,8 @@
-import warnings
 import numbers
+import warnings
+
 import numpy as np
+
 from .moments import moments_XX, moments_XXXY, moments_block
 
 __author__ = 'noe'
@@ -67,19 +69,19 @@ class Moments(object):
     def mean_y(self):
         return self.sy / self.w
 
-    def covar(self, bessel=True):
+    def covar(self, bessels_correction=True):
         """
         Return covariance matrix:
 
         Parameters:
         -----------
-        bessel : bool, optional, default=True
+        bessels_correction : bool, optional, default=True
             Use Bessel's correction in order to
             obtain an unbiased estimator of sample covariances.
 
         """
-        if bessel:
-            return self.Mxy/ (self.w-1)
+        if bessels_correction:
+            return self.Mxy / (self.w - 1)
         else:
             return self.Mxy / self.w
 
@@ -353,13 +355,13 @@ class RunningCovar(object):
         return self.storage_YY.moments.Mxy
 
     def cov_XX(self, bessel=True):
-        return self.storage_XX.moments.covar(bessel=bessel)
+        return self.storage_XX.moments.covar(bessels_correction=bessel)
 
     def cov_XY(self, bessel=True):
-        return self.storage_XY.moments.covar(bessel=bessel)
+        return self.storage_XY.moments.covar(bessels_correction=bessel)
 
     def cov_YY(self, bessel):
-        return self.storage_YY.moments.covar(bessel=bessel)
+        return self.storage_YY.moments.covar(bessels_correction=bessel)
 
     def clear(self):
         self.storage_XX.clear()

--- a/sktime/covariance/util/running_moments.py
+++ b/sktime/covariance/util/running_moments.py
@@ -121,18 +121,13 @@ class MomentsStorage(object):
         """ Store object X with weight w
         """
         if len(self.storage) == self.nsave:  # merge if we must
-            # print 'must merge'
             self.storage[-1].combine(moments, mean_free=self.remove_mean)
         else:  # append otherwise
-            # print 'append'
             self.storage.append(moments)
         # merge if possible
         while self._can_merge_tail():
-            # print 'merge: ',self.storage
             M = self.storage.pop()
-            # print 'pop last: ',self.storage
             self.storage[-1].combine(M, mean_free=self.remove_mean)
-            # print 'merged: ',self.storage
 
     @property
     def moments(self):
@@ -140,10 +135,8 @@ class MomentsStorage(object):
         """
         # collapse storage if necessary
         while len(self.storage) > 1:
-            # print 'collapse'
             M = self.storage.pop()
             self.storage[-1].combine(M, mean_free=self.remove_mean)
-        # print 'return first element'
         return self.storage[0]
 
     def clear(self):

--- a/sktime/data/util.py
+++ b/sktime/data/util.py
@@ -3,7 +3,10 @@ import numpy as np
 
 def timeshifted_split(inputs, lagtime: int, chunksize=None, n_splits=None):
     assert lagtime > 0
-    assert (chunksize is not None) ^ (n_splits is not None)
+    #assert (chunksize is not None) ^ (n_splits is not None)
+    if chunksize is None and n_splits is None:
+        chunksize = 500
+
     if not isinstance(inputs, (list, tuple)):
         inputs = [inputs]
 

--- a/sktime/data/util.py
+++ b/sktime/data/util.py
@@ -1,16 +1,20 @@
 import numpy as np
 
 
-def timeshifted_split(inputs, lagtime: int, chunksize=None, n_splits=None):
-    assert lagtime > 0
-    #assert (chunksize is not None) ^ (n_splits is not None)
-    if chunksize is None and n_splits is None:
-        chunksize = 500
+def timeshifted_split(inputs, lagtime: int, chunksize=1000, n_splits=None):
+    if lagtime < 0:
+        raise ValueError('lagtime has to be positive')
+    if int(chunksize) < 0:
+        raise ValueError('chunksize has to be positive')
 
-    if not isinstance(inputs, (list, tuple)):
+    if not isinstance(inputs, list):
+        if isinstance(inputs, tuple):
+            inputs = list(inputs)
         inputs = [inputs]
 
-    assert all(len(data) > lagtime for data in inputs)
+    if not all(len(data) > lagtime for data in inputs):
+        too_short_inputs = [i for i,x in enumerate(inputs) if len(x) < lagtime]
+        raise ValueError(f'Input contained to short (smaller than lagtime({lagtime}) at following indices: {too_short_inputs}')
 
     for data in inputs:
         data = np.asarray_chkfinite(data)

--- a/sktime/decomposition/tica.py
+++ b/sktime/decomposition/tica.py
@@ -275,7 +275,7 @@ class TICA(Estimator, Transformer):
         # online cov parameters
         self.reversible = reversible
         self._covar = OnlineCovariance(lagtime=lagtime, compute_c00=True, compute_c0t=True, compute_ctt=False, remove_data_mean=True,
-                                       reversible=self.reversible, bessel=False, ncov=ncov)
+                                       reversible=self.reversible, bessels_correction=False, ncov=ncov)
 
     def _create_model(self) -> TICAModel:
         return TICAModel()

--- a/tests/covariance/test_covar_estimator.py
+++ b/tests/covariance/test_covar_estimator.py
@@ -1,4 +1,5 @@
 import unittest
+
 import numpy as np
 
 from sktime.covariance.online_covariance import OnlineCovariance
@@ -151,7 +152,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XX_with_mean(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=False, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=False, bessels_correction=False)
         cc = est.fit(self.data).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_lag0)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_lag0)
@@ -160,7 +161,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XX_meanfree(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=True, bessels_correction=False)
         cc = est.fit(self.data).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_lag0)
         np.testing.assert_allclose(cc.cov_00, self.Mxx0_lag0)
@@ -169,7 +170,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XX_weightobj_withmean(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=False, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=False, bessels_correction=False)
         cc = est.fit(self.data, n_splits=10, weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_wobj_lag0)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_wobj_lag0)
@@ -178,7 +179,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XX_weightobj_meanfree(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, remove_data_mean=True, bessels_correction=False)
         cc = est.fit(self.data, weights=self.data_weights, n_splits=10).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_wobj_lag0)
         np.testing.assert_allclose(cc.cov_00, self.Mxx0_wobj_lag0)
@@ -187,9 +188,9 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_withmean(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, bessels_correction=False)
         cc = est.fit(self.data, n_splits=1).fetch_model()
-        assert not cc.bessel
+        assert not cc.bessels_correction
         np.testing.assert_allclose(cc.mean_0, self.mx)
         np.testing.assert_allclose(cc.mean_t, self.my)
         np.testing.assert_allclose(cc.cov_00, self.Mxx)
@@ -200,7 +201,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_meanfree(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, bessels_correction=False)
         cc = est.fit(self.data).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx)
         np.testing.assert_allclose(cc.mean_t, self.my)
@@ -212,7 +213,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_weightobj_withmean(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, bessels_correction=False)
         cc = est.fit(self.data, weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_wobj)
         np.testing.assert_allclose(cc.mean_t, self.my_wobj)
@@ -225,7 +226,7 @@ class TestCovarEstimator(unittest.TestCase):
     def test_XXXY_weightobj_meanfree(self):
         #TODO: tests do not pass for n_splits > 1!
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, bessels_correction=False)
         cc = est.fit(self.data, weights=self.data_weights, n_splits=1).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_wobj)
         np.testing.assert_allclose(cc.mean_t, self.my_wobj)
@@ -237,7 +238,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_sym_withmean(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, reversible=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, reversible=True, bessels_correction=False)
         cc = est.fit(self.data).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.m_sym)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_sym)
@@ -248,7 +249,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_sym_meanfree(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, reversible=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, reversible=True, bessels_correction=False)
         cc = est.fit(self.data, lagtime=self.lag).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.m_sym)
         np.testing.assert_allclose(cc.cov_00, self.Mxx0_sym)
@@ -259,7 +260,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_weightobj_sym_withmean(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, reversible=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=False, compute_c0t=True, reversible=True, bessels_correction=False)
         cc = est.fit(self.data, weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.m_sym_wobj)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_sym_wobj)
@@ -270,7 +271,7 @@ class TestCovarEstimator(unittest.TestCase):
 
     def test_XXXY_weightobj_sym_meanfree(self):
         # many passes
-        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, reversible=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, remove_data_mean=True, compute_c0t=True, reversible=True, bessels_correction=False)
         cc = est.fit(self.data, weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.m_sym_wobj)
         np.testing.assert_allclose(cc.cov_00, self.Mxx0_sym_wobj)
@@ -280,7 +281,7 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.cov_0t, self.Mxy0_sym_wobj[:, self.cols_2])
 
     def test_XX_meanconst(self):
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, bessels_correction=False)
         cc = est.fit(self.data - self.mean_const).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_c_lag0)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_c_lag0)
@@ -288,7 +289,7 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.cov_00, self.Mxx_c_lag0[:, self.cols_2])
 
     def test_XX_weighted_meanconst(self):
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=False, bessels_correction=False)
         cc = est.fit(self.data - self.mean_const, weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_c_wobj_lag0)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_c_wobj_lag0)
@@ -296,7 +297,7 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.cov_00, self.Mxx_c_wobj_lag0[:, self.cols_2])
 
     def test_XY_meanconst(self):
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, bessels_correction=False)
         cc = est.fit(self.Xc_lag0).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_c)
         np.testing.assert_allclose(cc.mean_t, self.my_c)
@@ -307,7 +308,7 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.cov_0t, self.Mxy_c[:, self.cols_2])
 
     def test_XY_weighted_meanconst(self):
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, bessels_correction=False)
         cc = est.fit(self.Xc_lag0,
                      weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.mx_c_wobj)
@@ -320,7 +321,7 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.cov_0t, self.Mxy_c_wobj[:, self.cols_2])
 
     def test_XY_sym_meanconst(self):
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, reversible=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, reversible=True, bessels_correction=False)
         cc = est.fit(self.Xc_lag0).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.m_c_sym)
         np.testing.assert_allclose(cc.cov_00, self.Mxx_c_sym)
@@ -330,7 +331,7 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.cov_0t, self.Mxy_c_sym[:, self.cols_2])
 
     def test_XY_sym_weighted_meanconst(self):
-        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, reversible=True, bessel=False)
+        est = OnlineCovariance(lagtime=self.lag, compute_c0t=True, reversible=True, bessels_correction=False)
         cc = est.fit(self.Xc_lag0, n_splits=1,
                      weights=self.data_weights).fetch_model()
         np.testing.assert_allclose(cc.mean_0, self.m_c_sym_wobj)

--- a/tests/covariance/test_covar_estimator.py
+++ b/tests/covariance/test_covar_estimator.py
@@ -365,27 +365,6 @@ class TestCovarEstimatorWeightsList(unittest.TestCase):
         # cov = covariance_lagged(data, lag=3, weights=weights, chunksize=10)
         assert np.all(cov.cov_00 < 1)
 
-    @unittest.skip("zero weights known to be broken #1117")
-    def test_weights_equal_to_zero(self):
-        n = 1000
-        data = [np.random.random(size=(n, 2)) for _ in range(5)]
-
-        # create some artificial correlations
-        data[0][:, 0] *= np.random.randint(n)
-
-        weights = [np.ones(n, dtype=np.float32) for _ in range(5)]
-        # omit the first trajectory by setting a weight close to zero.
-        weights[0][:] = 0
-        weights[0][800:850] = 1
-
-        est = OnlineCovariance(compute_c0t=True)
-        for x, w in zip(data, weights):
-            est.partial_fit((x[:-3], x[3:]), w[:-3])
-        cov = est.fetch_model()
-        zeros = sum((sum(w == 0) for w in weights))
-        assert np.all(cov.cov_00 < 1), cov.cov_00
-        assert np.all(cov.cov_00 > 0), cov.cov_00
-
     def test_non_matching_length(self):
         n = 100
         data = [np.random.random(size=(n, 2)) for n in range(3)]

--- a/tests/decomposition/test_tica.py
+++ b/tests/decomposition/test_tica.py
@@ -38,12 +38,12 @@ class TestTICA(unittest.TestCase):
         np.random.seed(0)
         data = np.random.randn(23000, 3)
 
-        est = TICA(dim=1)
+        est = TICA(lagtime=lag, dim=1)
         for X, Y in timeshifted_split(data, lagtime=lag, chunksize=chunk):
             est.partial_fit((X, Y))
         model1 = est.fetch_model().copy()
         # ------- run again with new chunksize -------
-        est.fit((data[:-lag], data[lag:]))
+        est.fit(data)
         model2 = est.fetch_model().copy()
 
         assert model1 != model2
@@ -56,7 +56,7 @@ class TestTICA(unittest.TestCase):
         o = np.ones((100, 10))
         z_lagged = (z[:-10], z[10:])
         o_lagged = (o[:-10], o[10:])
-        tica_obj = TICA()
+        tica_obj = TICA(lagtime=1)
         model = tica_obj.partial_fit(z_lagged).fetch_model()
         with self.assertRaises(ZeroRankError):
             _ = model.timescales(lagtime=1)
@@ -123,14 +123,13 @@ class TestTICAExtensive(unittest.TestCase):
         cls.cov_ref_0t = test_data['cov_ref_0t']
         cls.cov_ref_0t_nr = test_data['cov_ref_0t_nr']
         cls.data = test_data['data']
-        cls.timeshifted_data_pair = (cls.data[:-cls.lagtime], cls.data[cls.lagtime:])
 
         # perform unscaled TICA
-        cls.model_unscaled = TICA( dim=1, scaling=None).fit(cls.timeshifted_data_pair).fetch_model()
+        cls.model_unscaled = TICA(lagtime=cls.lagtime, dim=1, scaling=None).fit(cls.data).fetch_model()
         cls.transformed_data_unscaled = cls.model_unscaled.transform(cls.data)
 
         # non-reversible TICA
-        cls.model_nonrev = TICA( dim=1, scaling=None, reversible=False).fit(cls.timeshifted_data_pair) \
+        cls.model_nonrev = TICA(lagtime=cls.lagtime, dim=1, scaling=None, reversible=False).fit(cls.data) \
             .fetch_model()
         cls.transformed_data_nonrev = cls.model_nonrev.transform(cls.data)
 
@@ -141,7 +140,7 @@ class TestTICAExtensive(unittest.TestCase):
         assert np.max(np.abs(vars_nonrev - 1.0)) < 0.01
 
     def test_kinetic_map(self):
-        tica = TICA(dim=None, scaling='kinetic_map').fit(self.timeshifted_data_pair).fetch_model()
+        tica = TICA(lagtime=self.lagtime, dim=None, scaling='kinetic_map').fit(self.data).fetch_model()
         O = tica.transform(self.data)
         vars = np.var(O, axis=0)
         refs = tica.eigenvalues ** 2
@@ -163,15 +162,15 @@ class TestTICAExtensive(unittest.TestCase):
         assert self.model_unscaled.output_dimension() == 1
         assert self.model_nonrev.output_dimension() == 1
         # Test other variants
-        model = TICA(dim=1.0).fit(self.timeshifted_data_pair).fetch_model()
+        model = TICA(lagtime=self.lagtime, dim=1.0).fit(self.data).fetch_model()
         assert model.output_dimension() == 2
-        model = TICA(dim=.9).fit(self.timeshifted_data_pair).fetch_model()
+        model = TICA(lagtime=self.lagtime, dim=.9).fit(self.data).fetch_model()
         assert model.output_dimension() == 1
 
         invalid_dims = [0, 0.0, 1.1, -1]
         for invalid_dim in invalid_dims:
             with self.assertRaises(ValueError):
-                TICA(dim=invalid_dim)
+                TICA(lagtime=self.lagtime, dim=invalid_dim)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We can only have a consistent scikit-learn interface, when we allow only for one object to be passed to fit(), so it has to be a list or tuple. This then allows estimator chaining, e.g. in sklearns Pipeline class.

The prior approach of handing in x and y, where x is the instantaneous and y the time-lagged data, turned out to exclude the support for chaining and api consistency.