### PR TITLE
Estimator const input data

### DIFF
--- a/sktime/base.py
+++ b/sktime/base.py
@@ -156,7 +156,10 @@ class _ImmutableInputData(object):
 
         # first argument is x
         if len(args) == 0:
-            raise InputFormatError()
+            if 'data' in kwargs:
+                args = [kwargs['data']]
+            else:
+                raise InputFormatError(f'No input at all for fit(). Input was {args}, kw={kwargs}')
         value = args[0]
         if isinstance(value, np.ndarray):
             self._data.append(value)

--- a/sktime/base.py
+++ b/sktime/base.py
@@ -158,6 +158,8 @@ class _ImmutableInputData(object):
         if len(args) == 0:
             if 'data' in kwargs:
                 args = [kwargs['data']]
+            elif len(kwargs) == 1:
+                args = [kwargs[k] for k in kwargs.keys()]
             else:
                 raise InputFormatError(f'No input at all for fit(). Input was {args}, kw={kwargs}')
         value = args[0]

--- a/sktime/markovprocess/bayesian_msm.py
+++ b/sktime/markovprocess/bayesian_msm.py
@@ -139,12 +139,12 @@ class BayesianMSM(_MSMBaseEstimator):
     def _create_model(self) -> BayesianMSMPosterior:
         return BayesianMSMPosterior()
 
-    def fit(self, dtrajs, call_back: typing.Callable = None):
+    def fit(self, data, call_back: typing.Callable = None):
         """
 
         Parameters
         ----------
-        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+        data : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
             discrete trajectories, stored as integer ndarrays (arbitrary size)
             or a single ndarray for only one trajectory.
 
@@ -153,12 +153,12 @@ class BayesianMSM(_MSMBaseEstimator):
 
         """
         # conduct MLE estimation (superclass) first
-        super(BayesianMSM, self).fit(dtrajs)
+        super(BayesianMSM, self).fit(data)
         mle = MaximumLikelihoodMSM(lagtime=self.lagtime, reversible=self.reversible,
                                    statdist_constraint=self.statdist_constraint, count_mode=self.count_mode,
                                    sparse=self.sparse,
                                    dt_traj=self.dt_traj, mincount_connectivity=self.mincount_connectivity,
-                                   maxiter=self.maxiter, maxerr=self.maxerr).fit(dtrajs).fetch_model()
+                                   maxiter=self.maxiter, maxerr=self.maxerr).fit(data).fetch_model()
 
         # transition matrix sampler
         from msmtools.estimation import tmatrix_sampler

--- a/sktime/markovprocess/pcca.py
+++ b/sktime/markovprocess/pcca.py
@@ -100,6 +100,9 @@ class PCCAEstimator(Estimator):
         super(PCCAEstimator, self).__init__()
         self.n_metastable = n_metastable
 
+    # we do not check for input-data constness and type, because here we allow a MarkovStateModel as input.
+    _MUTABLE_INPUT_DATA = True
+
     def _create_model(self) -> PCCA:
         return PCCA()
 

--- a/sktime/markovprocess/reactive_flux.py
+++ b/sktime/markovprocess/reactive_flux.py
@@ -445,11 +445,16 @@ class ReactiveFluxEstimator(Estimator):
         self.B = B
         super(ReactiveFluxEstimator, self).__init__()
 
-    def fit(self, msm):
+    # we do not check for input-data constness and type, because here we allow a MarkovStateModel as input.
+    _MUTABLE_INPUT_DATA = True
+
+    def fit(self, msm, y=None):
         """
 
-        :param msm:
-        :return:
+        Parameters
+        ----------
+        msm: MarkovStateModel
+            the MSM contains the transition matrix for which the fluxes will will be computed.
         """
         T = msm.transition_matrix
         mu = msm.stationary_distribution

--- a/tests/base/test_immutale_data.py
+++ b/tests/base/test_immutale_data.py
@@ -1,0 +1,84 @@
+import unittest
+import numpy as np
+
+from sktime.base import Estimator, Model, InputFormatError
+
+
+class MyEstimator(Estimator):
+    def _create_model(self):
+        return Model()
+
+    # fit accidentally writes to input array!
+    def fit(self, x, y=None):
+        if isinstance(x, (list, tuple)):
+            x[0][0] = -1
+        else:
+            x[0] = -1
+        return self
+
+
+class MutableInputDataEstimator(Estimator):
+    _MUTABLE_INPUT_DATA = True
+
+    def _create_model(self):
+        return Model()
+
+    def fit(self, x):
+        x[0] = 5
+        return self
+
+
+class TestImmutableData(unittest.TestCase):
+    def setUp(self) -> None:
+        self.est = MyEstimator()
+
+    def test_modifying_raises(self):
+        data = np.arange(0, 10)
+
+        with self.assertRaises(ValueError) as cm:
+            self.est.fit(data)
+        if not 'read-only' in cm.exception.args[0]:
+            raise AssertionError('no read-only related value error')
+
+    def test_input_data(self):
+        data = [np.arange(0, 10)]
+
+        with self.assertRaises(ValueError):
+            self.est.fit(data)
+
+    def test_illegal_input_data_format(self):
+        """ should raise InputFormatError"""
+        data = 'illegal'
+        with self.assertRaises(InputFormatError):
+            self.est.fit(data)
+
+    def test_illegal_input_element(self):
+        data = [np.ones(1), np.ones(1), (np.arange(2), )]
+        with self.assertRaises(InputFormatError):
+            self.est.fit(data)
+
+    def test_flag_remains(self):
+        x = np.empty(3)
+        old_flag = x.flags.writeable
+        try:
+            self.est.fit(x)
+        except ValueError:
+            pass
+        assert x.flags.writeable == old_flag
+
+    def test_result_of_fit(self):
+        """ fit should return estimator instance itself """
+        class E(Estimator):
+            def _create_model(self):
+                return Model()
+
+            def fit(self, x):
+                self.y = x + 1
+                return self
+
+        result = E().fit(np.empty(0))
+        self.assertIsInstance(result, E)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/base/test_immutale_data.py
+++ b/tests/base/test_immutale_data.py
@@ -4,7 +4,7 @@ import numpy as np
 from sktime.base import Estimator, Model, InputFormatError
 
 
-class MyEstimator(Estimator):
+class EvilEstimator(Estimator):
     def _create_model(self):
         return Model()
 
@@ -28,9 +28,18 @@ class MutableInputDataEstimator(Estimator):
         return self
 
 
+class WellBehavingEstimator(Estimator):
+    def _create_model(self):
+        return Model()
+
+    def fit(self, x):
+        self.y = x + 1
+        return self
+
+
 class TestImmutableData(unittest.TestCase):
     def setUp(self) -> None:
-        self.est = MyEstimator()
+        self.est = EvilEstimator()
 
     def test_modifying_raises(self):
         data = np.arange(0, 10)
@@ -68,16 +77,12 @@ class TestImmutableData(unittest.TestCase):
 
     def test_result_of_fit(self):
         """ fit should return estimator instance itself """
-        class E(Estimator):
-            def _create_model(self):
-                return Model()
+        result = WellBehavingEstimator().fit(np.empty(0))
+        self.assertIsInstance(result, WellBehavingEstimator)
 
-            def fit(self, x):
-                self.y = x + 1
-                return self
-
-        result = E().fit(np.empty(0))
-        self.assertIsInstance(result, E)
+    def test_kw_data_passing(self):
+        """ Estimator.fit(data, **kwargs) should allow for fit(data=foobar) calls """
+        WellBehavingEstimator().fit(x=np.empty(0))
 
 
 if __name__ == '__main__':

--- a/tests/base/test_immutale_data.py
+++ b/tests/base/test_immutale_data.py
@@ -84,6 +84,11 @@ class TestImmutableData(unittest.TestCase):
         """ Estimator.fit(data, **kwargs) should allow for fit(data=foobar) calls """
         WellBehavingEstimator().fit(x=np.empty(0))
 
+    def test_kw_data_passing_y_arg(self):
+        class Supervised(WellBehavingEstimator):
+            def fit(self, x, y=None, foobar=None):
+                return super(Supervised, self).fit(x)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/markovprocess/test_msm.py
+++ b/tests/markovprocess/test_msm.py
@@ -76,10 +76,13 @@ class TestMSMSimple(unittest.TestCase):
         cls.tau = 1
 
         """Estimate MSM"""
+        import inspect
+        argspec = inspect.getfullargspec(MaximumLikelihoodMSM)
+        default_maxerr = argspec.defaults[argspec.args.index('maxerr') - 1]
         cls.C_MSM = count_matrix(cls.dtraj, cls.tau, sliding=True)
         cls.lcc_MSM = largest_connected_set(cls.C_MSM)
         cls.Ccc_MSM = largest_connected_submatrix(cls.C_MSM, lcc=cls.lcc_MSM)
-        cls.P_MSM = transition_matrix(cls.Ccc_MSM, reversible=True)
+        cls.P_MSM = transition_matrix(cls.Ccc_MSM, reversible=True, maxerr=default_maxerr)
         cls.mu_MSM = stationary_distribution(cls.P_MSM)
         cls.k = 3
         cls.ts = timescales(cls.P_MSM, k=cls.k, tau=cls.tau)

--- a/tests/markovprocess/test_msm.py
+++ b/tests/markovprocess/test_msm.py
@@ -973,7 +973,7 @@ class TestMSMMinCountConnectivity(unittest.TestCase):
         np.testing.assert_equal(msm_restrict_connectivity.count_model.active_set, self.active_set_restricted)
 
     def test_bmsm(self):
-        msm = BayesianMSM(lagtime=1, mincount_connectivity='1/n').fit(dtrajs=self.dtraj).fetch_model()
+        msm = BayesianMSM(lagtime=1, mincount_connectivity='1/n').fit(self.dtraj).fetch_model()
         msm_restricted = BayesianMSM(lagtime=1, mincount_connectivity=self.mincount_connectivity).fit(self.dtraj).fetch_model()
 
         np.testing.assert_equal(msm.prior.count_model.active_set, self.active_set_unrestricted)


### PR DESCRIPTION
We decorate Estimator.fit (and its overridden methods) to ensure that fit (and partial_fit) do not alter the passed data. We thereby constrain the input data to be ndarray or list, tuple of ndarray.
This behavior can be switched off, by setting the *_MUTABLE_INPUT_DATA* flag to True.
It makes sense to turn it off for two MSM related estimators, which take an MSM as input, as it avoids computing a new stationary vector.