### PR TITLE
Windows support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,5 +3,4 @@ stages:
   jobs:
   - template: ./devtools/azure-pipelines-linux.yml
   - template: ./devtools/azure-pipelines-osx.yml
-  #- template: ./devtools/azure-pipelines-win.yml
-
+  - template: ./devtools/azure-pipelines-win.yml

--- a/devtools/azure-pipelines-win.yml
+++ b/devtools/azure-pipelines-win.yml
@@ -2,13 +2,15 @@ jobs:
 - job:
   displayName: Win
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: vs2017-win2016
+    # vmImage: "windows-2019"
   strategy:
     matrix:
       Python37:
         CONDA_PY: '3.7'
 
   steps:
+  - template: checkout.yml
   - task: BatchScript@1
     inputs:
       filename: "$(CONDA)\\Scripts\\activate.bat"

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -7,10 +7,12 @@ source:
   path: ../..
 
 build:
+  skip: true  # [win and vc<14]
   script_env:
-   - OMP_NUM_THREADS
-   - AGENT_BUILDDIRECTORY
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+    - OMP_NUM_THREADS
+    - AGENT_BUILDDIRECTORY
+  script:
+    - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
   build:
@@ -22,7 +24,7 @@ requirements:
   host:
     - cython
     - intel-openmp # [osx]
-    - numpy
+    - numpy >=1.14
     - python
     - scipy
     - setuptools
@@ -30,6 +32,7 @@ requirements:
 
   run:
     - intel-openmp # [osx]
+    - vs2015_runtime  # [win]
     - msmtools
     - {{ pin_compatible('numpy') }}
     - python

--- a/devtools/conda-setup+build.yml
+++ b/devtools/conda-setup+build.yml
@@ -3,7 +3,13 @@ steps:
       conda config --add channels conda-forge
       conda config --set always_yes true
       conda config --set quiet true
-      conda install conda-build conda-verify
+    displayName: Configure conda
+  - bash: |
+      python -m pip install --upgrade pip
+      conda update --all
+    displayName: Update conda
+  - bash: |
+      conda install conda-build conda-verify pip
     displayName: 'Install dependencies'
     continueOnError: false
   - bash: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,9 @@
 requires = [
  "setuptools",
  "wheel",
- "numpy>=1.10",
+ "numpy>=1.14",
  "Cython",
  "scipy",
  # TODO: include again once https://github.com/pybind/pybind11/issues/1067 is fixed.
  #"pybind11",
  ]
-

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,12 @@ class Build(build_ext):
         np_inc = _np_inc()
         pybind_inc = 'lib/pybind11/include'
         # TODO: this is platform dependent, e.g. win should be treated differently.
-        cxx_flags = ['-std=c++14']
+        if self.compiler.compiler_type == 'msvc':
+            cxx_flags = ['/EHsc', '/std:c++latest', '/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version()]
+            extra_link_args.append('/machine:X64')
+        else:
+            cxx_flags = ['-std=c++14']
         has_openmp = supports_omp(self.compiler)
-
         if has_openmp:
             extra_compile_args += ['-fopenmp' if sys.platform != 'darwin' else '-fopenmp=libiomp5']
             if sys.platform.startswith('linux'):
@@ -77,8 +80,6 @@ class Build(build_ext):
             ext.include_dirs.append(pybind_inc)
             if ext.language == 'c++':
                 ext.extra_compile_args += cxx_flags
-
-            if has_openmp:
                 ext.extra_compile_args += extra_compile_args
                 ext.extra_link_args += extra_link_args
                 ext.define_macros += define_macros

--- a/sktime/markov/hmm/_bindings/include/OutputModelUtils.h
+++ b/sktime/markov/hmm/_bindings/include/OutputModelUtils.h
@@ -203,9 +203,13 @@ constexpr dtype pi() { return 3.141592653589793238462643383279502884e+00; }
  */
 template<typename dtype>
 constexpr dtype sample(dtype o, dtype mu, dtype sigma) {
+    #ifndef _WIN32
     double c = 1.0 / (std::sqrt(2.0 * pi<dtype>()) * sigma);
     double d = (o - mu) / sigma;
     return c * exp(-0.5 * d * d);
+    #else
+    return exp(-0.5 * ((o - mu) / sigma) * ((o - mu) / sigma)) / (std::sqrt(2.0 * pi<dtype>()) * sigma);
+    #endif
 }
 
 template<typename dtype>


### PR DESCRIPTION
Add windows worker for python 3.7 to the pipeline. For this to work with pep 517 installation I needed to upgrade minimum numpy version to 1.14.