### PR TITLE
Refactor vamp

### DIFF
--- a/docs/source/_templates/base_nomodule.rst
+++ b/docs/source/_templates/base_nomodule.rst
@@ -1,7 +1,0 @@
-{% set escapedname = objname|escape %}
-{% set title = "*" ~ objtype ~ "* " ~ escapedname %}
-{{ title | underline }}
-
-.. currentmodule:: {{ module }}
-
-.. auto{{ objtype }}:: {{ objname }}

--- a/docs/source/_templates/class_nomodule.rst
+++ b/docs/source/_templates/class_nomodule.rst
@@ -7,7 +7,7 @@
 .. autoclass:: {{ objname }}
 
    {% block methods %}
-   .. automethod:: __init__
+   .. automethod:: {{ name }}.__init__
 
    {% if methods %}
    .. rubric:: {{ _('Methods') }}

--- a/docs/source/index_dimreduction.rst
+++ b/docs/source/index_dimreduction.rst
@@ -78,11 +78,6 @@ are based on estimating covariance matrices using the `covariance estimator <api
 This estimator makes use of an online algorithm proposed in :cite:`ix-dimredux-chan1982updating` so that not the entire data has
 to be kept in memory.
 
-In particular, this means that TICA and VAMP not only have a :code:`fit`-method (`tica.fit() <api/generated/sktime.decomposition.TICA.rst#sktime.decomposition.TICA.fit>`_,
-`vamp.fit() <api/generated/sktime.decomposition.VAMP.rst#sktime.decomposition.VAMP.fit>`_), but also a
-:code:`partial_fit`-method (`tica.partial_fit() <api/generated/sktime.decomposition.TICA.rst#sktime.decomposition.TICA.partial_fit>`_,
-`vamp.partial_fit() <api/generated/sktime.decomposition.VAMP.rst#sktime.decomposition.VAMP.partial_fit>`_).
-
 .. code-block:: python
 
     estimator = sktime.decomposition.TICA(lagtime=tau)  # creating an estimator

--- a/docs/source/notebooks/tica.ipynb
+++ b/docs/source/notebooks/tica.ipynb
@@ -70,9 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tica = sktime.decomposition.TICA(\n",
-    "    lagtime=1  # the lag time \"tau\"\n",
-    ")"
+    "tica = sktime.decomposition.TICA()"
    ]
   },
   {
@@ -81,9 +79,9 @@
    "source": [
     "yielding an estimator which operates on symmetrized correlation matrices and takes as many eigenvalues as required to capture 95% of the kinetic variance of the time series.\n",
     "\n",
-    "It can be fit by calling [fit()](../api/generated/sktime.decomposition.TICA.rst#sktime.decomposition.TICA.fit) or [partial_fit()](../api/generated/sktime.decomposition.TICA.rst#sktime.decomposition.TICA.partial_fit).\n",
+    "It can be fit by calling [fit()](../api/generated/sktime.decomposition.TICA.rst#sktime.decomposition.TICA.fit). This method distinguishes between arguments which are covariance matrices in form of a symmetrized [CovarianceModel](../api/generated/sktime.covariance.CovarianceModel.rst#sktime.covariance.CovarianceModel) and raw timeseries data. In case of raw timeseries data, the lagtime $\\tau$ must be provided, otherwise it is inferred from the covariance model.\n",
     "\n",
-    "_Note_: TICA per default makes reversible estimates and then assumes, that the data is in equilibrium. In case of reversible estimate but non-equilibrium data (e.g., many short trajectories which start off-equilibrium), [Koopman reweighting](#Koopman-reweighting) can be used."
+    "_Note_: TICA makes reversible estimates and then assumes, that the data is in equilibrium. In case of reversible estimate but non-equilibrium data (e.g., many short trajectories which start off-equilibrium), [Koopman reweighting](#Koopman-reweighting) can be used."
    ]
   },
   {
@@ -92,7 +90,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tica.fit(np.random.uniform(size=(1000, 5)))"
+    "data = np.random.uniform(size=(1000, 5))\n",
+    "tica.fit(data, lagtime=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Optionally, covariances can be estimated and then used to fit the estimator:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "covariances = sktime.decomposition.TICA.covariance_estimator(lagtime=1).fit(data)\n",
+    "tica.fit(covariances)"
    ]
   },
   {
@@ -259,7 +275,6 @@
    "outputs": [],
    "source": [
     "tica = sktime.decomposition.TICA(\n",
-    "    lagtime=1,  # time shift is one step\n",
     "    dim=1  # fix projection dimension explicitly\n",
     ")"
    ]
@@ -268,7 +283,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now the [tica model](../api/generated/sktime.decomposition.TICAModel.rst#sktime.decomposition.TICAModel) can be estimated.\n",
+    "Now the [tica model](../api/generated/sktime.decomposition.CovarianceKoopmanModel.rst#sktime.decomposition.CovarianceKoopmanModel) can be estimated.\n",
     "\n",
     "_Note_: In the reversible (default) case, this assumes that the data comes from an equilibirum distribution. Applying the method as-is to short off-equilibrium data produces heavily biased estimates. See [Koopman reweighting](#Koopman-reweighting) (or the corresponding [API docs](../api/generated/sktime.covariance.KoopmanWeightingEstimator.rst#sktime.covariance.KoopmanWeightingEstimator)) for a reweighting technique that extends TICA to non-equilibrium data."
    ]
@@ -279,7 +294,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tica_model = tica.fit(feature_trajectory).fetch_model()  # fit and fetch model"
+    "tica_model = tica.fit(feature_trajectory, lagtime=1).fetch_model()  # fit and fetch model"
    ]
   },
   {
@@ -301,7 +316,7 @@
     "ax1.set_xlabel('x')\n",
     "ax1.set_ylabel('t')\n",
     "\n",
-    "dxy = tica_model.eigenvectors[:, 0]  # dominant tica component\n",
+    "dxy = tica_model.singular_vectors_left[:, 0]  # dominant tica component\n",
     "\n",
     "ax2.scatter(*(feature_trajectory.T), marker='.')\n",
     "x, y = np.meshgrid(\n",
@@ -355,7 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tica_model.feature_tic_correlation"
+    "tica_model.feature_component_correlation"
    ]
   },
   {
@@ -393,7 +408,7 @@
    "outputs": [],
    "source": [
     "tica.scaling = None\n",
-    "tica_model = tica.fit(feature_trajectory).fetch_model()"
+    "tica_model = tica.fit(feature_trajectory, lagtime=1).fetch_model()"
    ]
   },
   {
@@ -410,7 +425,7 @@
    "outputs": [],
    "source": [
     "tica.scaling = \"kinetic_map\"  # default\n",
-    "tica_model_kinetic_map = tica.fit(feature_trajectory).fetch_model()"
+    "tica_model_kinetic_map = tica.fit(feature_trajectory, lagtime=1).fetch_model()"
    ]
   },
   {
@@ -427,7 +442,7 @@
    "outputs": [],
    "source": [
     "tica.scaling = \"commute_map\"\n",
-    "tica_model_commute_map = tica.fit(feature_trajectory).fetch_model()"
+    "tica_model_commute_map = tica.fit(feature_trajectory, lagtime=1).fetch_model()"
    ]
   },
   {
@@ -470,7 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tica = sktime.decomposition.TICA(lagtime=1, dim=1)"
+    "tica = sktime.decomposition.TICA(dim=1)"
    ]
   },
   {
@@ -486,7 +501,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "koopman_estimator = sktime.covariance.KoopmanWeightingEstimator(lagtime=tica.lagtime)\n",
+    "koopman_estimator = sktime.covariance.KoopmanWeightingEstimator(lagtime=1)\n",
     "reweighting_model = koopman_estimator.fit(feature_trajectory).fetch_model()"
    ]
   },
@@ -503,7 +518,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tica_model_reweighted = tica.fit(feature_trajectory, weights=reweighting_model).fetch_model()"
+    "tica_model_reweighted = tica.fit(feature_trajectory, lagtime=1, weights=reweighting_model).fetch_model()"
    ]
   },
   {
@@ -525,7 +540,7 @@
     "ax1.set_xlabel('x')\n",
     "ax1.set_ylabel('t')\n",
     "\n",
-    "dxy = tica_model.eigenvectors[:, 0]  # dominant tica component\n",
+    "dxy = tica_model.singular_vectors_left[:, 0]  # dominant tica component\n",
     "\n",
     "ax2.scatter(*(feature_trajectory.T), marker='.')\n",
     "x, y = np.meshgrid(\n",

--- a/docs/source/notebooks/tica.ipynb
+++ b/docs/source/notebooks/tica.ipynb
@@ -270,7 +270,7 @@
    "source": [
     "Now the [tica model](../api/generated/sktime.decomposition.TICAModel.rst#sktime.decomposition.TICAModel) can be estimated.\n",
     "\n",
-    "_Note_: In the reversible (default) case, this assumes that the data comes from an equilibirum distribution. Applying the method as-is to short off-equilibrium data produces heavily biased estimates. See [Koopman reweighting](#Koopman-reweighting) (or the corresponding [API docs](../api/generated/sktime.covariance.KoopmanEstimator.rst#sktime.covariance.KoopmanEstimator)) for a reweighting technique that extends TICA to non-equilibrium data."
+    "_Note_: In the reversible (default) case, this assumes that the data comes from an equilibirum distribution. Applying the method as-is to short off-equilibrium data produces heavily biased estimates. See [Koopman reweighting](#Koopman-reweighting) (or the corresponding [API docs](../api/generated/sktime.covariance.KoopmanWeightingEstimator.rst#sktime.covariance.KoopmanWeightingEstimator)) for a reweighting technique that extends TICA to non-equilibrium data."
    ]
   },
   {
@@ -459,7 +459,7 @@
    "source": [
     "## Koopman reweighting\n",
     "\n",
-    "If the data that is used for estimation (for the most part) is not in equilibrium, the estimate can become heavily biased in case reversibility is enforced. Koopman reweighting <cite data-cite=\"nbtica-wu2016variational\">(Wu, 2016)</cite> assigns weights to each frame of the time series so that also off-equilibrium data can be used. In scikit-time, a [Koopman estimator](../api/generated/sktime.covariance.KoopmanEstimator.rst#sktime.covariance.KoopmanEstimator) is implemented, which learns appropriate weights from data. The corresponding [Koopman model](../api/generated/sktime.covariance.KoopmanModel.rst#sktime.covariance.KoopmanModel) can be used as an argument in TICA's `fit`. \n",
+    "If the data that is used for estimation (for the most part) is not in equilibrium, the estimate can become heavily biased in case reversibility is enforced. Koopman reweighting <cite data-cite=\"nbtica-wu2016variational\">(Wu, 2016)</cite> assigns weights to each frame of the time series so that also off-equilibrium data can be used. In scikit-time, a [Koopman weighting estimator](../api/generated/sktime.covariance.KoopmanWeightingEstimator.rst#sktime.covariance.KoopmanWeightingEstimator) is implemented, which learns appropriate weights from data. The corresponding [Koopman model](../api/generated/sktime.covariance.KoopmanWeightingModel.rst#sktime.covariance.KoopmanWeightingModel) can be used as an argument in TICA's `fit`. \n",
     "\n",
     "This reweighting technique becomes necessary as soon as the available data is not a single long trajectory which equilibrates and then is in an equilibrium state for the rest of the time but rather if many short and at least initially off-equilibrium trajectories are used. "
    ]
@@ -486,7 +486,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "koopman_estimator = sktime.covariance.KoopmanEstimator(lagtime=tica.lagtime)\n",
+    "koopman_estimator = sktime.covariance.KoopmanWeightingEstimator(lagtime=tica.lagtime)\n",
     "reweighting_model = koopman_estimator.fit(feature_trajectory).fetch_model()"
    ]
   },

--- a/docs/source/notebooks/vamp.ipynb
+++ b/docs/source/notebooks/vamp.ipynb
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given the data, all that is left to do is fitting a model by providing covariances and obtaining it from the estimator or using the [from_data](../api/generated/sktime.decomposition.VAMP.rst#sktime.decomposition.VAMP.from_data) shortcut directly."
+    "Given the data, all that is left to do is to fit a model by providing covariances and obtaining it from the estimator or using `fit` on the timeseries directly. In the latter case, a lagtime must be provided."
    ]
   },
   {
@@ -100,14 +100,14 @@
    "outputs": [],
    "source": [
     "covars = sktime.decomposition.VAMP.covariance_estimator(\n",
-    "    lagtime=1  # the time lag under which the covariance matrices are estimated\n",
+    "    lagtime=1  # the time lag with which the covariance matrices are estimated\n",
     ").fit(feature_trajectory).fetch_model()\n",
     "vamp_estimator.fit(covars)\n",
     "model = vamp_estimator.fetch_model()\n",
     "\n",
     "# ---- or ----\n",
     "\n",
-    "model = sktime.decomposition.VAMP.from_data(feature_trajectory, dim=1, lagtime=1)"
+    "model = sktime.decomposition.VAMP(dim=1).fit(feature_trajectory, lagtime=1).fetch_model()"
    ]
   },
   {
@@ -207,7 +207,7 @@
     "C_{tt} &= \\mathbb{E}_t[(\\chi_1(x_{t+\\tau})-\\mu_1)(\\chi_1(x_{t+\\tau})-\\mu_1)^\\top]\n",
     "\\end{aligned}$$\n",
     "\n",
-    "can be computed by the [Covariances estimator](../api/generated/sktime.covariance.Covariance.rst#sktime.covariance.Covariance). <span style=\"color:red\">Otherwise the covariance matrices should be estimated by ...</span> These covariance matrices can be accessed in the computed model:"
+    "can be computed by the [Covariances estimator](../api/generated/sktime.covariance.Covariance.rst#sktime.covariance.Covariance). These covariance matrices can be accessed in the computed model:"
    ]
   },
   {
@@ -587,7 +587,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = sktime.decomposition.VAMP.from_data(kde_trajectory, lagtime=100)"
+    "model = sktime.decomposition.VAMP().fit(kde_trajectory, lagtime=100).fetch_model()"
    ]
   },
   {

--- a/docs/source/notebooks/vamp.ipynb
+++ b/docs/source/notebooks/vamp.ipynb
@@ -51,7 +51,6 @@
    "outputs": [],
    "source": [
     "vamp_estimator = sktime.decomposition.VAMP(\n",
-    "    lagtime=1,  # the number of steps tau under which K is estimated\n",
     "    dim=1  # projection dimension\n",
     ")"
    ]
@@ -91,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given the data, all that is left to do is fitting a model and obtaining it from the estimator."
+    "Given the data, all that is left to do is fitting a model by providing covariances and obtaining it from the estimator or using the [from_data](../api/generated/sktime.decomposition.VAMP.rst#sktime.decomposition.VAMP.from_data) shortcut directly."
    ]
   },
   {
@@ -100,8 +99,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vamp_estimator.fit(feature_trajectory)\n",
-    "model = vamp_estimator.fetch_model();"
+    "covars = sktime.decomposition.VAMP.covariance_estimator(\n",
+    "    lagtime=1  # the time lag under which the covariance matrices are estimated\n",
+    ").fit(feature_trajectory).fetch_model()\n",
+    "vamp_estimator.fit(covars)\n",
+    "model = vamp_estimator.fetch_model()\n",
+    "\n",
+    "# ---- or ----\n",
+    "\n",
+    "model = sktime.decomposition.VAMP.from_data(feature_trajectory, dim=1, lagtime=1)"
    ]
   },
   {
@@ -175,25 +181,25 @@
     "\n",
     "This matrix is actually a finite-dimensional approximation of the Koopman operator\n",
     "\n",
-    "$$ \\mathcal{K}_\\tau g(x) = \\mathbb{E}[g(x_{t+\\tau} | x_t = x) ], $$\n",
+    "$$ \\mathcal{K}_\\tau f(x) = \\mathbb{E}[f(x_{t+\\tau} | x_t = x) ], $$\n",
     "\n",
-    "which maps for given $x_t$ to the expected value of an arbitrary observable $g$ at time $t+\\tau$. This in particular means that the matrix $K$ depends on $\\mathcal{K}_\\tau$, i.e., models at different lagtimes approximate different operators and are thus not directly comparable.\n",
+    "which maps for given $x_t$ observed through $f$ to the expected value of an arbitrary observable $g$ at time $t+\\tau$. This in particular means that the matrix $K$ depends on $\\mathcal{K}_\\tau$, i.e., models at different lagtimes approximate different operators and are thus not directly comparable.\n",
     "\n",
     "One can show (Theorem 1 of <cite data-cite=\"nbvamp-wu2020variational\">(Wu, 2020)</cite>), that the best approximation of $K$ to $\\mathcal{K}_\\tau$ is achieved for\n",
     "\n",
     "$$ \\bar K=\\mathrm{diag}(\\sigma_1,\\ldots,\\sigma_k), $$\n",
     "\n",
-    "when $f = (\\psi_1,\\ldots,\\psi_k)$ and $g=(\\phi_1,\\ldots,\\phi_k)$. Here $\\sigma_i$, $\\psi_i$, $\\phi_i$ are the singular values, left singular functions, and right singular functions of $\\mathcal{K}_\\tau^*\\mathcal{K}_\\tau$, respectively. The $\\psi_i$ and $\\phi_i$ should form an orthonormal basis of respective spaces. In particular this means that in this representation,\n",
+    "when $f = (\\psi_1,\\ldots,\\psi_k)$ and $g=(\\phi_1,\\ldots,\\phi_k)$. Here $\\sigma_i$, $\\psi_i$, $\\phi_i$ are the singular values, left singular functions, and right singular functions of $\\mathcal{K}_\\tau^*\\mathcal{K}_\\tau$, respectively. The operator $\\mathcal{K}_\\tau^*\\mathcal{K}_\\tau$ relates to a foward-backward mapping in time. The $\\psi_i$ and $\\phi_i$ should form an orthonormal basis of respective spaces. In particular this means that in this representation,\n",
     "\n",
-    "$$ \\mathbb{E}[\\phi_i(x_{t+\\tau})] = \\sigma_i\\mathbb{E}[\\psi_i(x_t)] \\text{ and } \\bar{\\mathcal{K}}_\\tau g = \\sum_i \\sigma_i \\langle g, \\phi_i \\rangle_{\\rho_1} \\psi_i, $$\n",
+    "$$ \\mathbb{E}[\\phi_i(x_{t+\\tau})] = \\sigma_i\\mathbb{E}[\\psi_i(x_t)] \\text{ and } \\bar{\\mathcal{K}}_\\tau f = \\sum_i \\sigma_i \\langle f, \\phi_i \\rangle_{\\rho_1} \\psi_i, $$\n",
     "\n",
     "where $\\bar{\\mathcal{K}}_\\tau$ denotes the projected Koopman operator.\n",
     "\n",
     "The [VAMP estimator](../api/generated/sktime.decomposition.VAMP.rst#sktime.decomposition.VAMP) first and foremost solves the following problem:\n",
     "\n",
-    "> Given a basis set $\\chi^\\top = (\\chi_0, \\chi_1)^\\top$ so that $f = U^\\top \\chi_0$ and $g=V^\\top \\chi_1$, find weights $U,V\\in\\mathbb{R}^{m\\times k}$ so that the resulting linear model $\\mathbb{E}[g(x_{t+\\tau})] = K^\\top \\mathbb{E}[f(x_t)]$ is optimal.\n",
+    "> Given a basis set $\\chi^\\top = (\\chi_0, \\chi_1)^\\top$ so that $f = U^\\top \\chi_0$ and $g=V^\\top \\chi_1$, find weights $U,V\\in\\mathbb{R}^{m\\times k}$ so that the resulting linear model $\\mathbb{E}[g(x_{t+\\tau})] = K^\\top \\mathbb{E}[f(x_t)]$ is optimal. For the purposes of estimation the potentially different basis sets $\\chi_0$ and $\\chi_1$ are assumed to be equal. In practice one can achieve this by simply concatenating the observable trajectories in time.\n",
     "\n",
-    "To this end, (instantaneous and time-lagged) mean-free covariance matrices $C_{00}, C_{0t}, C_{tt}$ with\n",
+    "When there are significantly more frames than dimensions in the dataset, the (instantaneous and time-lagged) mean-free covariance matrices $C_{00}, C_{0t}, C_{tt}$ with\n",
     "\n",
     "$$\\begin{aligned}\n",
     "C_{00} &= \\mathbb{E}_t[(\\chi_0(x_t)-\\mu_0)(\\chi_0(x_t)-\\mu_0)^\\top], \\\\\n",
@@ -201,7 +207,7 @@
     "C_{tt} &= \\mathbb{E}_t[(\\chi_1(x_{t+\\tau})-\\mu_1)(\\chi_1(x_{t+\\tau})-\\mu_1)^\\top]\n",
     "\\end{aligned}$$\n",
     "\n",
-    "are computed, see also the [Covariances estimator](../api/generated/sktime.covariance.Covariance.rst#sktime.covariance.Covariance). These covariance matrices can be accessed in the computed model:"
+    "can be computed by the [Covariances estimator](../api/generated/sktime.covariance.Covariance.rst#sktime.covariance.Covariance). <span style=\"color:red\">Otherwise the covariance matrices should be estimated by ...</span> These covariance matrices can be accessed in the computed model:"
    ]
   },
   {
@@ -223,7 +229,7 @@
    "source": [
     "Based on these covariances, the truncated SVD\n",
     "\n",
-    "$$\\bar K = C_{00}^{-1/2}C_{0t}C_{tt}^{-1/2} \\approx U' \\mathrm{diag}(\\sigma_1,\\ldots,\\sigma_k) V' $$\n",
+    "$$\\bar K = C_{00}^{-1/2}C_{0t}C_{tt}^{-1/2} \\approx U' \\mathrm{diag}(\\sigma_1,\\ldots,\\sigma_k) V'^\\top $$\n",
     "\n",
     "is evaluated, where $\\bar K$ is the Koopman matrix for normalized basis functions $C_{00}^{-1/2}\\chi_0$ and $C_{tt}^{-1/2}\\chi_1$, respectively. The truncation is based on the [dim](../api/generated/sktime.decomposition.VAMP.rst#sktime.decomposition.VAMP.dim) parameter of the estimator.\n",
     "\n",
@@ -258,7 +264,43 @@
     "\n",
     "is then given by $K = \\mathrm{diag}(\\sigma_1,\\ldots,\\sigma_k)$, $f_i = u_i^\\top\\chi_0$, and $g_i = v_i^\\top\\chi_1$.\n",
     "\n",
-    "The model's [transform(data, right=False)](../api/generated/sktime.decomposition.VAMPModel.rst#sktime.decomposition.VAMPModel.transform) gives access to $f$ and $g$:"
+    "The model's [transform(data, forward=True)](../api/generated/sktime.decomposition.CovarianceKoopmanModel.rst#sktime.decomposition.CovarianceKoopmanModel.transform) gives access to $f$ and $g$:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = model.transform(feature_trajectory, right=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.singular_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.output_dimension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x.shape"
    ]
   },
   {
@@ -393,7 +435,7 @@
    "outputs": [],
    "source": [
     "vamp_estimator.scaling = \"kinetic_map\"\n",
-    "scaled_model = vamp_estimator.fit(feature_trajectory).fetch_model()\n",
+    "scaled_model = vamp_estimator.fit(covars).fetch_model()\n",
     "\n",
     "# plotting transformations\n",
     "plt.plot(model.transform(feature_trajectory, right=False), label=\"unscaled\")\n",
@@ -509,7 +551,9 @@
    "source": [
     "n_grid_x = 20\n",
     "n_grid_y = 10\n",
-    "kde_trajectory = pbf_simulator.transform_to_density(trajectory, n_grid_x=n_grid_x, n_grid_y=n_grid_y, n_jobs=8)"
+    "kde_trajectory = pbf_simulator.transform_to_density(\n",
+    "    trajectory, n_grid_x=n_grid_x, n_grid_y=n_grid_y, n_jobs=8\n",
+    ")"
    ]
   },
   {
@@ -543,8 +587,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "estimator = sktime.decomposition.VAMP(lagtime=100)\n",
-    "model = estimator.fit(kde_trajectory).fetch_model()"
+    "model = sktime.decomposition.VAMP.from_data(kde_trajectory, lagtime=100)"
    ]
   },
   {
@@ -560,8 +603,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "projection_left = model.transform(kde_trajectory, right=False)\n",
-    "projection_right = model.transform(kde_trajectory, right=True)"
+    "projection_left = model.transform(kde_trajectory, forward=True)\n",
+    "projection_right = model.transform(kde_trajectory, forward=False)"
    ]
   },
   {
@@ -636,7 +679,7 @@
     "\n",
     "$$ \\mathbb{E}[g(x_{t+\\tau})] = K^\\top \\mathbb{E}[f(x_t)] $$\n",
     "\n",
-    "we can also apply the forward operator to frames by calling [forward()](../api/generated/sktime.decomposition.VAMPModel.rst#sktime.decomposition.VAMPModel.forward). It also allows to project onto specific processes by setting all other singular values to zero."
+    "we can also apply the forward operator to frames by calling [forward()](../api/generated/sktime.decomposition.CovarianceKoopmanModel.rst#sktime.decomposition.CovarianceKoopmanModel.forward). It also allows to project onto specific processes by setting all other singular values to zero."
    ]
   },
   {
@@ -686,9 +729,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "forward_component0 = model.forward(kde_trajectory, component=0)\n",
-    "forward_component1 = model.forward(kde_trajectory, component=1)\n",
-    "forward_component0123 = model.forward(kde_trajectory, component=[0, 1, 2, 3])"
+    "forward_component0 = model.forward(kde_trajectory, components=0)\n",
+    "forward_component1 = model.forward(kde_trajectory, components=1)\n",
+    "forward_component0123 = model.forward(kde_trajectory, components=[0, 1, 2, 3])"
    ]
   },
   {

--- a/sktime/base.py
+++ b/sktime/base.py
@@ -136,7 +136,7 @@ class Model(_base_methods_mixin):
 
         Returns
         -------
-        copy : Model
+        copy
             A new copy of this model.
         """
         import copy
@@ -270,10 +270,10 @@ class _ImmutableInputData(object):
                     self._data.append(x)
                 else:
                     raise InputFormatError(f'Invalid input element in position {i}, only numpy.ndarrays allowed.')
-        elif isinstance(value, Model):
+        elif isinstance(value, (Model, Estimator)):
             self._data.append(value)
         else:
-            raise InputFormatError(f'Only model, ndarray or list/tuple of ndarray allowed. '
+            raise InputFormatError(f'Only estimator, model, ndarray or list/tuple of ndarray allowed. '
                                    f'But was of type {type(value)}: {value}.')
 
     def __enter__(self):

--- a/sktime/base.py
+++ b/sktime/base.py
@@ -195,6 +195,15 @@ class Estimator(_base_methods_mixin):
         """
         return self._model
 
+    @property
+    def has_model(self) -> bool:
+        r""" Property reporting whether this estimator contains an estimated model. This assumes that the model
+        is initialized with `None` otherwise.
+
+        :type: bool
+        """
+        return self._model is not None
+
     def __getattribute__(self, item):
         if (item == 'fit' or item == 'partial_fit') and not self._MUTABLE_INPUT_DATA:
             fit = super(Estimator, self).__getattribute__(item)

--- a/sktime/covariance/__init__.py
+++ b/sktime/covariance/__init__.py
@@ -41,4 +41,4 @@ Implementations
 
 from .util.moments import moments_XX, moments_XXXY, moments_block, covar, covars
 from .covariance import Covariance, CovarianceModel
-from .covariance import KoopmanEstimator, KoopmanModel
+from .covariance import KoopmanWeightingEstimator, KoopmanWeightingModel

--- a/sktime/covariance/__init__.py
+++ b/sktime/covariance/__init__.py
@@ -7,7 +7,7 @@ Estimation
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     Covariance
     CovarianceModel
@@ -20,8 +20,8 @@ Koopman reweighting
     :toctree: generated/
     :template: class_nomodule.rst
 
-    KoopmanEstimator
-    KoopmanModel
+    KoopmanWeightingEstimator
+    KoopmanWeightingModel
 
 ===============================================================================
 Implementations
@@ -29,7 +29,7 @@ Implementations
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     covar
     covars

--- a/sktime/data/__init__.py
+++ b/sktime/data/__init__.py
@@ -7,7 +7,7 @@ API
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     double_well_discrete
     ellipsoids
@@ -19,7 +19,7 @@ Utilities
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     timeshifted_split
 
@@ -29,7 +29,7 @@ Implementations
 
 .. autosummary::
     :toctree: generated/impl/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     double_well_dataset.DoubleWellDiscrete
     ellipsoids_dataset.Ellipsoids

--- a/sktime/decomposition/__init__.py
+++ b/sktime/decomposition/__init__.py
@@ -36,6 +36,6 @@ VAMP
     VAMP
 """
 
-from .tica import TICA, TICAModel
+from .tica import TICA
 from .vamp import VAMP
 from .koopman import KoopmanBasisTransform, IdentityKoopmanBasisTransform, KoopmanModel, CovarianceKoopmanModel

--- a/sktime/decomposition/__init__.py
+++ b/sktime/decomposition/__init__.py
@@ -1,13 +1,26 @@
 r"""
 .. currentmodule: sktime.decomposition
 
+=============
+Koopman model
+=============
+
+.. autosummary::
+    :toctree: generated/
+    :template: class_nomodule.rst
+
+    KoopmanModel
+    CovarianceKoopmanModel
+    KoopmanBasisTransform
+    IdentityKoopmanBasisTransform
+
 ===============================================================================
 TICA
 ===============================================================================
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     TICA
     TICAModel
@@ -18,11 +31,11 @@ VAMP
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     VAMP
-    VAMPModel
 """
 
 from .tica import TICA, TICAModel
-from .vamp import VAMP, VAMPModel
+from .vamp import VAMP
+from .koopman import KoopmanBasisTransform, IdentityKoopmanBasisTransform, KoopmanModel, CovarianceKoopmanModel

--- a/sktime/decomposition/__init__.py
+++ b/sktime/decomposition/__init__.py
@@ -23,7 +23,6 @@ TICA
     :template: class_nomodule.rst
 
     TICA
-    TICAModel
 
 ===============================================================================
 VAMP

--- a/sktime/decomposition/koopman.py
+++ b/sktime/decomposition/koopman.py
@@ -1,0 +1,208 @@
+from typing import Optional, Union, List
+
+import numpy as np
+
+from ..base import Model, Transformer
+from ..numeric import is_diagonal_matrix
+from ..util import cached_property
+
+
+class KoopmanBasisTransform(object):
+    r""" Transforms a system's observable
+
+    .. math:: f(x_t) = (\chi^{(1)}(x_t),\ldots,\chi^{(n)})^\top
+
+    to another basis
+
+    .. math:: \tilde f(x_t) = T (f(x_t) - \mu ),
+
+    where :math:`T` is the transformation matrix and :math:`\mu` a constant mean value that is subtracted.
+    """
+
+    def __init__(self, mean, transformation_matrix):
+        self._mean = mean
+        self._transformation_matrix = transformation_matrix
+
+    @cached_property
+    def backward_transformation_matrix(self):
+        return np.linalg.pinv(self._transformation_matrix)
+
+    def __call__(self, data, inverse=False, dim=None):
+        r""" Applies the basis transform to data.
+
+        Parameters
+        ----------
+        data : (T, n) ndarray
+            Data consisting of `T` frames in `n` dimensions.
+        inverse : bool, default=False
+            Whether to apply the forward or backward operation, i.e., :math:`T (f(x_t) - \mu )` or
+            :math:`T^{-1} f(x_t) + \mu`, respectively.
+        dim : int or None
+            Number of dimensions to restrict to, removes the all but the first :math:`n` basis transformation vectors.
+            Can only be not `None` if `inverse` is False.
+
+        Returns
+        -------
+        transformed_data : (T, k) ndarray
+            Transformed data. If :math:`T\in\mathbb{R}^{n\times m}`, we get :math:`k=\min\{m, \mathrm{dim}\}`.
+        """
+        if not inverse:
+            return (data - self._mean[:dim]) @ self._transformation_matrix[:, :dim]
+        else:
+            if dim is not None:
+                raise ValueError("This currently only works for the forward transform.")
+            return data @ self.backward_transformation_matrix + self._mean
+
+
+class IdentityKoopmanBasisTransform(KoopmanBasisTransform):
+
+    def __init__(self):
+        super().__init__(0., 1.)
+
+    def backward_transformation_matrix(self):
+        return 1.
+
+    def __call__(self, data, inverse=False, dim=None):
+        return data
+
+
+class KoopmanModel(Model, Transformer):
+    r""" Model which contains a finite-dimensional Koopman operator (or approximation thereof).
+    It describes the temporal evolution of observable space, i.e.,
+
+    .. math:: \mathbb{E}[g(x_{t+\tau}] = K^\top \mathbb{E}[f(x_t)],
+
+    where :math:`K\in\mathbb{R}^{n\times m}` is the Koopman operator, :math:`x_t` the system's state at time :math:`t`,
+    and $f$ and $g$ observables of the system's state.
+    """
+
+    def __init__(self, operator: np.ndarray,
+                 basis_transform_forward: Optional[KoopmanBasisTransform],
+                 basis_transform_backward: Optional[KoopmanBasisTransform],
+                 output_dimension=None):
+        r""" Creates a new Koopman model.
+
+        Parameters
+        ----------
+        operator : (n, n) ndarray
+            Applies the transform :math:`K^\top` in the modified basis.
+        basis_transform_forward : KoopmanBasisTransform or None
+            Transforms the current state :math:`f(x_t)` to the basis in which the Koopman operator is defined.
+            If `None`, this defaults to the identity operation.
+        basis_transform_backward : KoopmanBasisTransform or None
+            Transforms the future state :math:`g(x_t)` to the basis in which the Koopman operator is defined.
+            If `None`, this defaults to the identity operation
+        """
+        super().__init__()
+        if basis_transform_forward is None:
+            basis_transform_forward = IdentityKoopmanBasisTransform()
+        if basis_transform_backward is None:
+            basis_transform_backward = IdentityKoopmanBasisTransform()
+        self._operator = np.asarray_chkfinite(operator)
+        self._basis_transform_forward = basis_transform_forward
+        self._basis_transform_backward = basis_transform_backward
+        if output_dimension is not None and not is_diagonal_matrix(self.operator):
+            raise ValueError("Output dimension can only be set if the Koopman operator is a diagonal matrix. This"
+                             "can be achieved through the VAMP estimator.")
+        self._output_dimension = output_dimension
+
+    @property
+    def operator(self) -> np.ndarray:
+        r""" The operator :math:`K` so that :math:`\mathbb{E}[g(x_{t+\tau}] = K^\top \mathbb{E}[f(x_t)]` in transformed
+        bases.
+        """
+        return self._operator
+
+    @cached_property
+    def operator_inverse(self) -> np.ndarray:
+        r""" Inverse of the operator :math:`K`, i.e., :math:`K^{-1}`. Potentially also pseudo-inverse. """
+        return np.linalg.pinv(self.operator)
+
+    @property
+    def basis_transform_forward(self) -> KoopmanBasisTransform:
+        r"""Transforms the basis of :math:`\mathbb{E}[f(x_t)]` to the one in which the Koopman operator is defined. """
+        return self._basis_transform_forward
+
+    @property
+    def basis_transform_backward(self) -> KoopmanBasisTransform:
+        r"""Transforms the basis of :math:`\mathbb{E}[g(x_{t+\tau})]` to the one in which
+        the Koopman operator is defined. """
+        return self._basis_transform_backward
+
+    @property
+    def output_dimension(self):
+        r"""The output dimension of the :meth:`transform` pass."""
+        return self._output_dimension
+
+    def forward(self, trajectory: np.ndarray, components: Optional[Union[int, List[int]]]) -> np.ndarray:
+        r""" Applies the forward transform to the trajectory in non-transformed space. Given the Koopman operator
+        :math:`\Sigma`, transformations  :math:`V^\top - \mu_t` and :math:`U^\top -\mu_0` for
+        bases :math:`f` and :math:`g`, respectively, this is achieved by transforming each frame :math:`X_t` with
+
+        .. math::
+            \hat{X}_{t+\tau} = (V^\top)^{-1} \Sigma U^\top (X_t - \mu_0) + \mu_t.
+
+        If the model stems from a :class:`VAMP <sktime.decomposition.VAMP>` estimator, :math:`V` are the left
+        singular vectors, :math:`\Sigma` the singular values, and :math:`U` the right singular vectors.
+
+        Parameters
+        ----------
+        trajectory : (T, n) ndarray
+            The input trajectory
+        components : int or list of int or None
+            Optional arguments for the Koopman operator if appropriate. If the model stems from
+            a :class:`VAMP <sktime.decomposition.VAMP>` estimator, these are the component(s) to project onto.
+            If None, all processes are taken into account, if list of integer, this sets all singular values
+            to zero but the "components"th ones.
+
+        Returns
+        -------
+        predictions : (T, n) ndarray
+            The predicted trajectory.
+        """
+        if components is not None:
+            if not is_diagonal_matrix(self.operator):
+                raise ValueError("A subselection of components is only possible if the koopman operator is a diagonal"
+                                 "matrix! This can be achieved by using the VAMP estimator, yielding appropriate"
+                                 "basis transforms from covariance matrices.")
+            operator = np.zeros_like(self.operator)
+            if not isinstance(components, (list, tuple)):
+                components = [components]
+            for ii in components:
+                operator[ii, ii] = self.operator[ii]
+        else:
+            operator = self.operator
+        output_trajectory = np.empty_like(trajectory)
+        # todo i think this can be vectorized by just not looping over t?
+        for t, frame in enumerate(trajectory):
+            x = self.basis_transform_forward(trajectory[t])  # map into basis in which K is defined
+            x = operator.T @ x  # apply operator, we are now in the modified basis of g
+            x = self.basis_transform_backward(x, inverse=True)  # map back to observable basis
+            output_trajectory[t] = x
+        return output_trajectory
+
+    def transform(self, data, forward=True, propagate=False, **kwargs):
+        r"""Projects the data into the Koopman operator basis, possibly discarding nonrelevant dimensions.
+
+        Parameters
+        ----------
+        data : ndarray(T, n)
+            the input data
+        forward : bool, default=True
+            Whether to use forward or backward transform for projection.
+        propagate : bool, default=False
+            Whether to propagate the projection with :math:`K^\top`.
+
+        Returns
+        -------
+        projection : ndarray(T, m)
+            The projected data.
+            In case of VAMP, if `forward` is True, projection will be on the right singular
+            functions. Otherwise, projection will be on the left singular functions.
+        """
+        if forward:
+            transform = self.basis_transform_forward(data, dim=self._output_dimension)
+            return self.operator.T @ transform if propagate else transform
+        else:
+            transform = self.basis_transform_backward(data, dim=self._output_dimension)
+            return self.operator_inverse.T @ transform if propagate else transform

--- a/sktime/decomposition/vamp.py
+++ b/sktime/decomposition/vamp.py
@@ -25,453 +25,11 @@ from typing import Optional, Union, List
 import numpy as np
 
 from .koopman import CovarianceKoopmanModel, KoopmanBasisTransform
-from ..base import Model, Estimator, Transformer
+from ..base import Estimator, Transformer
 from ..covariance.covariance import Covariance, CovarianceModel
-from ..numeric import mdot
-from ..numeric.eigen import spd_inv_split, spd_inv_sqrt
-from ..util import cached_property
+from ..numeric.eigen import spd_inv_split
 
-__all__ = ['VAMP', 'VAMPModel']
-
-
-class VAMPModel(Model, Transformer):
-    r""" Model which was estimated from a :class:`VAMP` estimator.
-
-    See Also
-    --------
-    VAMP : vamp estimator
-    """
-
-    _DiagonalizationResults = namedtuple("DiagonalizationResults", ['rank0', 'rankt', 'singular_values',
-                                                                    'left_singular_vecs', 'right_singular_vecs'])
-
-    def __init__(self, cov: CovarianceModel, dim=None, epsilon=1e-6, scaling=None):
-        r""" Creates a new model instance.
-
-        Parameters
-        ----------
-        cov : CovarianceModel
-            Estimated covariances.
-        dim : int or float or None, optional, default=None
-            Dimension parameter, see :attr:`VAMP.dim` for a more detailed description. The effective dimension can be
-            obtained from :attr:`output_dimension`.
-        epsilon : float, optional, default=1e-6
-            Singular value cutoff parameter, see :attr:`VAMP.epsilon`.
-        scaling : str or None, optional, default=None
-            Scaling parameter which was applied to singular values for additional structure in the projected space.
-            See the respective estimator for details.
-            Whether right or left eigenvectors should be used for projection. In case `right==False` (default),
-            left eigenvectors are used, right eigenvectors otherwise.
-        """
-        super().__init__()
-        self._cov = cov
-        self._dim = dim
-        self._epsilon = epsilon
-        self._scaling = scaling
-        self._right = right
-
-    def _invalidate_caches(self):
-        r""" Invalidates all cached properties and causes them to be re-evaluated """
-        for member in self.__class__.__dict__.values():
-            if isinstance(member, cached_property):
-                member.invalidate()
-        self._eigenvalues = None
-        self._stationary_distribution = None
-
-    @property
-    def right(self) -> bool:
-        r""" Whether right or left eigenvectors should be used for projection. """
-        return self._right
-
-    @right.setter
-    def right(self, value: bool):
-        self._right = value
-
-    @property
-    def epsilon(self) -> float:
-        r""" Singular value cutoff. """
-        return self._epsilon
-
-    @property
-    def dim(self) -> Optional[Real]:
-        r""" Dimension parameter used for estimating this model. Affects the effective :attr:`output_dimension`.
-
-        :getter: Yields the currently configured dim parameter.
-        :setter: Sets a new dimension cutoff, triggers re-evaluation of decomposition.
-        :type: int or float or None
-        """
-        return self._dim
-
-    @dim.setter
-    def dim(self, value: Optional[Real]):
-        if isinstance(value, Integral) and value <= 0:
-            # first test against Integral as `isinstance(1, Real)` also evaluates to True
-            raise ValueError("Invalid dimension parameter, if it is given in terms of the dimension (integer), "
-                             "must be positive.")
-        elif isinstance(value, Real) and (value <= 0. or float(value) > 1.0):
-            raise ValueError("Invalid dimension parameter, if it is given in terms of a floating point, "
-                             "can only be in the interval (0, 1].")
-        elif value is not None and not isinstance(value, (Integral, Real)):
-            raise ValueError("Invalid type for dimension, got {}".format(value))
-        self._dim = value
-        self._invalidate_caches()
-
-    @property
-    def scaling(self) -> Optional[str]:
-        """Scaling of projection. Can be :code:`None`, 'kinetic map', or 'km' """
-        return self._scaling
-
-    @property
-    def singular_vectors_left(self) -> np.ndarray:
-        """Tranformation matrix that represents the linear map from mean-free feature space
-        to the space of left singular functions."""
-        return self._decomposition.left_singular_vecs
-
-    @property
-    def singular_vectors_right(self) -> np.ndarray:
-        """Tranformation matrix that represents the linear map from mean-free feature space
-        to the space of right singular functions."""
-        return self._decomposition.right_singular_vecs
-
-    @property
-    def singular_values(self) -> np.ndarray:
-        """ The singular values of the half-weighted Koopman matrix. """
-        return self._decomposition.singular_values
-
-    @property
-    def cov(self) -> CovarianceModel:
-        r""" Estimated covariances. """
-        return self._cov
-
-    @property
-    def mean_0(self) -> np.ndarray:
-        r""" Shortcut to :attr:`mean_0 <sktime.covariance.CovarianceModel.mean_0>`. """
-        return self.cov.mean_0
-
-    @property
-    def mean_t(self) -> np.ndarray:
-        r""" Shortcut to :attr:`mean_t <sktime.covariance.CovarianceModel.mean_t>`. """
-        return self.cov.mean_t
-
-    @property
-    def cov_00(self) -> np.ndarray:
-        r""" Shortcut to :attr:`cov_00 <sktime.covariance.CovarianceModel.cov_00>`. """
-        return self.cov.cov_00
-
-    @property
-    def cov_0t(self) -> np.ndarray:
-        r""" Shortcut to :attr:`cov_0t <sktime.covariance.CovarianceModel.cov_0t>`. """
-        return self.cov.cov_0t
-
-    @property
-    def cov_tt(self) -> np.ndarray:
-        r""" Shortcut to :attr:`cov_tt <sktime.covariance.CovarianceModel.cov_tt>`. """
-        return self.cov.cov_tt
-
-    @staticmethod
-    def _cumvar(singular_values) -> np.ndarray:
-        cumvar = np.cumsum(singular_values ** 2)
-        cumvar /= cumvar[-1]
-        return cumvar
-
-    @property
-    def cumvar(self) -> np.ndarray:
-        """ Cumulative kinetic variance. """
-        return VAMPModel._cumvar(self.singular_values)
-
-    @staticmethod
-    def _dimension(rank0, rankt, dim, singular_values) -> int:
-        """ output dimension """
-        if dim is None or (isinstance(dim, float) and dim == 1.0):
-            return min(rank0, rankt)
-        if isinstance(dim, float):
-            return np.searchsorted(VAMPModel._cumvar(singular_values), dim) + 1
-        else:
-            return np.min([rank0, rankt, dim])
-
-    @property
-    def output_dimension(self) -> int:
-        """ Effective Output dimension. """
-        rank0 = self._decomposition.rank0
-        rankt = self._decomposition.rankt
-        return self._dimension(rank0, rankt, self.dim, self.singular_values)
-
-    def expectation(self, observables, statistics, lag_multiple=1, observables_mean_free=False,
-                    statistics_mean_free=False):
-        r"""Compute future expectation of observable or covariance using the approximated Koopman operator.
-
-        Parameters
-        ----------
-        observables : np.ndarray((input_dimension, n_observables))
-            Coefficients that express one or multiple observables in
-            the basis of the input features.
-
-        statistics : np.ndarray((input_dimension, n_statistics)), optional
-            Coefficients that express one or multiple statistics in
-            the basis of the input features.
-            This parameter can be None. In that case, this method
-            returns the future expectation value of the observable(s).
-
-        lag_multiple : int
-            If > 1, extrapolate to a multiple of the estimator's lag
-            time by assuming Markovianity of the approximated Koopman
-            operator.
-
-        observables_mean_free : bool, default=False
-            If true, coefficients in `observables` refer to the input
-            features with feature means removed.
-            If false, coefficients in `observables` refer to the
-            unmodified input features.
-
-        statistics_mean_free : bool, default=False
-            If true, coefficients in `statistics` refer to the input
-            features with feature means removed.
-            If false, coefficients in `statistics` refer to the
-            unmodified input features.
-
-        Notes
-        -----
-        A "future expectation" of a observable g is the average of g computed
-        over a time window that has the same total length as the input data
-        from which the Koopman operator was estimated but is shifted
-        by lag_multiple*tau time steps into the future (where tau is the lag
-        time).
-
-        It is computed with the equation:
-
-        .. math::
-
-            \mathbb{E}[g]_{\rho_{n}}=\mathbf{q}^{T}\mathbf{P}^{n-1}\mathbf{e}_{1}
-
-        where
-
-        .. math::
-
-            P_{ij}=\sigma_{i}\langle\psi_{i},\phi_{j}\rangle_{\rho_{1}}
-
-        and
-
-        .. math::
-
-            q_{i}=\langle g,\phi_{i}\rangle_{\rho_{1}}
-
-        and :math:`\mathbf{e}_{1}` is the first canonical unit vector.
-
-
-        A model prediction of time-lagged covariances between the
-        observable f and the statistic g at a lag-time of lag_multiple*tau
-        is computed with the equation:
-
-        .. math::
-
-            \mathrm{cov}[g,\,f;n\tau]=\mathbf{q}^{T}\mathbf{P}^{n-1}\boldsymbol{\Sigma}\mathbf{r}
-
-        where :math:`r_{i}=\langle\psi_{i},f\rangle_{\rho_{0}}` and
-        :math:`\boldsymbol{\Sigma}=\mathrm{diag(\boldsymbol{\sigma})}` .
-        """
-        if lag_multiple <= 0:
-            raise ValueError("lag_multiple <= 0 not implemented")
-
-        dim = self.output_dimension
-
-        S = np.diag(np.concatenate(([1.0], self.singular_values[0:dim])))
-        V = self.singular_vectors_right[:, 0:dim]
-        U = self.singular_vectors_left[:, 0:dim]
-        m_0 = self.mean_0
-        m_t = self.mean_t
-
-        if lag_multiple == 1:
-            P = S
-        else:
-            p = np.zeros((dim + 1, dim + 1))
-            p[0, 0] = 1.0
-            p[1:, 0] = U.T.dot(m_t - m_0)
-            p[1:, 1:] = U.T.dot(self.cov_tt).dot(V)
-            P = np.linalg.matrix_power(S.dot(p), lag_multiple - 1).dot(S)
-
-        Q = np.zeros((observables.shape[1], dim + 1))
-        if not observables_mean_free:
-            Q[:, 0] = observables.T.dot(m_t)
-        Q[:, 1:] = observables.T.dot(self.cov_tt).dot(V)
-
-        if statistics is not None:
-            # compute covariance
-            R = np.zeros((statistics.shape[1], dim + 1))
-            if not statistics_mean_free:
-                R[:, 0] = statistics.T.dot(m_0)
-            R[:, 1:] = statistics.T.dot(self.cov_00).dot(U)
-
-        if statistics is not None:
-            # compute lagged covariance
-            return Q.dot(P).dot(R.T)
-            # TODO: discuss whether we want to return this or the transpose
-            # TODO: from MSMs one might expect to first index to refer to the statistics, here it is the other way round
-        else:
-            # compute future expectation
-            return Q.dot(P)[:, 0]
-
-    @cached_property
-    def _decomposition(self) -> _DiagonalizationResults:
-        """Performs SVD on covariance matrices and save left, right singular vectors and values in the model."""
-        L0 = spd_inv_split(self.cov_00, epsilon=self.epsilon)
-        rank0 = L0.shape[1] if L0.ndim == 2 else 1
-        Lt = spd_inv_split(self.cov_tt, epsilon=self.epsilon)
-        rankt = Lt.shape[1] if Lt.ndim == 2 else 1
-
-        W = np.dot(L0.T, self.cov_0t).dot(Lt)
-        from scipy.linalg import svd
-        A, s, BT = svd(W, compute_uv=True, lapack_driver='gesvd')
-
-        singular_values = s
-
-        # don't pass any values in the argument list that call _diagonalize again!!!
-        m = VAMPModel._dimension(rank0, rankt, self.dim, singular_values)
-
-        U = np.dot(L0, A[:, :m])
-        V = np.dot(Lt, BT[:m, :].T)
-
-        # scale vectors
-        if self.scaling is not None:
-            U *= s[np.newaxis, 0:m]  # scaled left singular functions induce a kinetic map
-            V *= s[np.newaxis, 0:m]  # scaled right singular functions induce a kinetic map wrt. backward propagator
-
-        return VAMPModel._DiagonalizationResults(
-            rank0=rank0, rankt=rankt, singular_values=singular_values, left_singular_vecs=U, right_singular_vecs=V
-        )
-
-    def forward(self, trajectory: np.ndarray, component: Optional[Union[int, List[int]]] = None):
-        r"""Applies the forward transform to the trajectory in non-whitened space. This is achieved by
-        transforming each frame :math:`X_t` with
-
-        .. math::
-            \hat{X}_{t+\tau} = (V^\top)^{-1} \Sigma U^\top (X_t - \mu_0) + \mu_t,
-
-        where :math:`V` are the left singular vectors, :math:`\Sigma` the singular values, and :math:`U` the right
-        singular vectors.
-
-        Parameters
-        ----------
-        trajectory : (T, n) ndarray
-            The input trajectory
-        component : int or list of int or None
-            The component(s) to project onto. If None, all processes are taken into account, if integer
-            sets all singular values to zero but the "component"th one.
-
-        Returns
-        -------
-        predictions : (T, n) ndarray
-            The predicted trajectory.
-        """
-        if component is not None:
-            singval = np.zeros((len(self.singular_values), len(self.singular_values)))
-            if not isinstance(component, (list, tuple)):
-                component = [component]
-            for ii in component:
-                singval[ii, ii] = self.singular_values[ii]
-        else:
-            singval = np.diag(self.singular_values)
-
-        output_trajectory = np.empty_like(trajectory)
-        VT_inv = np.linalg.pinv(self.singular_vectors_right.T)
-        for t, frame in enumerate(trajectory):
-            output_trajectory[t] = VT_inv @ singval @ np.dot(self.singular_vectors_left.T,
-                                                             frame - self.mean_0) + self.mean_t
-
-        return output_trajectory
-
-    def transform(self, data, right=None):
-        r"""Projects the data onto the dominant singular functions.
-
-        Parameters
-        ----------
-        data : ndarray(n, m)
-            the input data
-        right : bool or None, optional, default=None
-            Whether to use left or right eigenvectors for projection, overrides :attr:`right` if not None.
-
-        Returns
-        -------
-        Y : ndarray(n,)
-            the projected data
-            If `right` is True, projection will be on the right singular
-            functions. Otherwise, projection will be on the left singular
-            functions.
-        """
-        right = self.right if right is None else right
-        if right:
-            X_meanfree = data - self.mean_t
-            Y = np.dot(X_meanfree, self.singular_vectors_right[:, :self.output_dimension])
-        else:
-            X_meanfree = data - self.mean_0
-            Y = np.dot(X_meanfree, self.singular_vectors_left[:, :self.output_dimension])
-        return Y
-
-    def score(self, test_model=None, score_method='VAMP2'):
-        """Compute the VAMP score for this model or the cross-validation score between self and a second model.
-
-        Parameters
-        ----------
-        test_model : VAMPModel, optional, default=None
-
-            If `test_model` is not None, this method computes the cross-validation score
-            between self and `test_model`. It is assumed that self was estimated from
-            the "training" data and `test_model` was estimated from the "test" data. The
-            score is computed for one realization of self and `test_model`. Estimation
-            of the average cross-validation score and partitioning of data into test and
-            training part is not performed by this method.
-
-            If `test_model` is None, this method computes the VAMP score for the model
-            contained in self.
-
-        score_method : str, optional, default='VAMP2'
-            Available scores are based on the variational approach
-            for Markov processes :cite:`vampscore-wu2020variational`:
-
-            *  'VAMP1'  Sum of singular values of the half-weighted Koopman matrix :cite:`vampscore-wu2020variational`.
-                        If the model is reversible, this is equal to the sum of
-                        Koopman matrix eigenvalues, also called Rayleigh quotient :cite:`vampscore-wu2020variational`.
-            *  'VAMP2'  Sum of squared singular values of the half-weighted Koopman
-                        matrix :cite:`vampscore-wu2020variational`. If the model is reversible, this is
-                        equal to the kinetic variance :cite:`vampscore-noe2015kinetic`.
-            *  'VAMPE'  Approximation error of the estimated Koopman operator with respect to
-                        the true Koopman operator up to an additive constant :cite:`vampscore-wu2020variational` .
-
-        Returns
-        -------
-        score : float
-            If `test_model` is not None, returns the cross-validation VAMP score between
-            self and `test_model`. Otherwise return the selected VAMP-score of self.
-
-        References
-        ----------
-        .. bibliography:: /references.bib
-            :style: unsrt
-            :filter: docname in docnames
-            :keyprefix: vampscore-
-        """
-        if test_model is None:
-            test_model = self
-        Uk = self.singular_vectors_left[:, 0:self.output_dimension]
-        Vk = self.singular_vectors_right[:, 0:self.output_dimension]
-        res = None
-        if score_method == 'VAMP1' or score_method == 'VAMP2':
-            A = spd_inv_sqrt(Uk.T.dot(test_model.cov_00).dot(Uk), epsilon=self.epsilon)
-            B = Uk.T.dot(test_model.cov_0t).dot(Vk)
-            C = spd_inv_sqrt(Vk.T.dot(test_model.cov_tt).dot(Vk), epsilon=self.epsilon)
-            ABC = mdot(A, B, C)
-            if score_method == 'VAMP1':
-                res = np.linalg.norm(ABC, ord='nuc')
-            elif score_method == 'VAMP2':
-                res = np.linalg.norm(ABC, ord='fro') ** 2
-        elif score_method == 'VAMPE':
-            Sk = np.diag(self.singular_values[0:self.output_dimension])
-            res = np.trace(2.0 * mdot(Vk, Sk, Uk.T, test_model.cov_0t)
-                           - mdot(Vk, Sk, Uk.T, test_model.cov_00, Uk, Sk, Vk.T, test_model.cov_tt))
-        else:
-            raise ValueError('"score" should be one of VAMP1, VAMP2 or VAMPE')
-        assert res is not None
-        # add the contribution (+1) of the constant singular functions to the result
-        return res + 1
+__all__ = ['VAMP']
 
 
 class VAMP(Estimator, Transformer):
@@ -481,7 +39,7 @@ class VAMP(Estimator, Transformer):
 
     See Also
     --------
-    VAMPModel : type of model produced by this estimator
+    CovarianceKoopmanModel : type of model produced by this estimator
 
     Notes
     -----
@@ -575,14 +133,12 @@ class VAMP(Estimator, Transformer):
         :keyprefix: vamp-
     """
 
-    def __init__(self, lagtime: int, dim: Optional[Real] = None, scaling: Optional[str] = None, right: bool = False,
-                 epsilon: float = 1e-6, ncov: Union[int] = float('inf')):
+    def __init__(self, dim: Optional[Real] = None, scaling: Optional[str] = None,
+                 epsilon: float = 1e-6):
         r""" Creates a new VAMP estimator.
 
         Parameters
         ----------
-        lagtime : int
-            The lagtime to be used for estimating covariances.
         dim : float or int, optional, default=None
             Number of dimensions to keep:
 
@@ -602,33 +158,15 @@ class VAMP(Estimator, Transformer):
               Only the left singular functions induce a kinetic map wrt the
               conventional forward propagator. The right singular functions induce
               a kinetic map wrt the backward propagator.
-        right: bool, optional, default=None
-            Whether to compute the right singular functions.
-
-            If :code:`right==True`, :meth:`transform` and :meth:`VAMPModel.transform` will use the right singular
-            functions.
-
-            Beware that only `frames[tau:, :]` of each trajectory returned
-            by :meth:`transform` contain valid values of the right singular
-            functions. Conversely, only `frames[0:-tau, :]` of each
-            trajectory returned by :meth:`transform` contain valid values of
-            the left singular functions. The remaining frames might
-            possibly be interpreted as some extrapolation.
         epsilon : float, optional, default=1e-6
             Eigenvalue cutoff. Eigenvalues of :math:`C_{00}` and :math:`C_{11}`
             with norms <= epsilon will be cut off. The remaining number of
             eigenvalues together with the value of `dim` define the size of the output.
-        ncov : int or float('inf'), optional, default=float('inf')
-            Limit the memory usage of the algorithm from :cite:`vamp-chan1982updating` to an amount that corresponds
-            to ncov additional copies of each correlation matrix.
         """
         super(VAMP, self).__init__()
         self.dim = dim
         self.scaling = scaling
-        self.right = right
         self.epsilon = epsilon
-        self.ncov = ncov
-        self.lagtime = lagtime
 
     _DiagonalizationResults = namedtuple("DiagonalizationResults", ['rank0', 'rankt', 'singular_values',
                                                                     'left_singular_vecs', 'right_singular_vecs'])
@@ -638,16 +176,6 @@ class VAMP(Estimator, Transformer):
         cumvar = np.cumsum(singular_values ** 2)
         cumvar /= cumvar[-1]
         return cumvar
-
-    @staticmethod
-    def _dimension(rank0, rankt, dim, singular_values) -> int:
-        """ output dimension """
-        if dim is None or (isinstance(dim, float) and dim == 1.0):
-            return min(rank0, rankt)
-        if isinstance(dim, float):
-            return np.searchsorted(VAMP._cumvar(singular_values), dim) + 1
-        else:
-            return np.min([rank0, rankt, dim])
 
     @staticmethod
     def _decomposition(covariances, epsilon, scaling, dim) -> _DiagonalizationResults:
@@ -663,14 +191,13 @@ class VAMP(Estimator, Transformer):
 
         singular_values = s
 
-        # don't pass any values in the argument list that call _diagonalize again!!!
-        m = VAMP._dimension(rank0, rankt, dim, singular_values)
+        m = CovarianceKoopmanModel.effective_output_dimension(rank0, rankt, dim, singular_values)
 
         U = np.dot(L0, A[:, :m])
         V = np.dot(Lt, BT[:m, :].T)
 
         # scale vectors
-        if scaling is not None:
+        if scaling is not None and scaling in ("km", "kinetic_map"):
             U *= s[np.newaxis, 0:m]  # scaled left singular functions induce a kinetic map
             V *= s[np.newaxis, 0:m]  # scaled right singular functions induce a kinetic map wrt. backward propagator
 
@@ -679,12 +206,53 @@ class VAMP(Estimator, Transformer):
         )
 
     @staticmethod
-    def from_data(data: np.ndarray, lagtime, dim, scaling, epsilon, ncov):
-        covar = Covariance(lagtime=lagtime, compute_c00=True, compute_c0t=True, compute_ctt=True,
-                           remove_data_mean=True, reversible=False, bessels_correction=False,
-                           ncov=ncov)
+    def covariance_estimator(lagtime: int, ncov: Union[int] = float('inf')):
+        r""" Yields a properly configured covariance estimator so that its model can be used as input for the vamp
+        estimator.
+
+        Parameters
+        ----------
+        lagtime : int
+            Positive integer denoting the time shift which is considered for autocorrelations.
+        ncov : int or float('inf'), optional, default=float('inf')
+            Limit the memory usage of the algorithm from :cite:`vamp-chan1982updating` to an amount that corresponds
+            to ncov additional copies of each correlation matrix.
+
+        Returns
+        -------
+        estimator : Covariance
+            Covariance estimator.
+        """
+        return Covariance(lagtime=lagtime, compute_c0t=True, compute_ctt=True, remove_data_mean=True, reversible=False,
+                          bessels_correction=False, ncov=ncov)
+
+    @staticmethod
+    def from_data(data: Union[np.ndarray, List[np.ndarray]], lagtime: int, dim: Optional[Real] = None,
+                  scaling: Optional[str] = None, epsilon: float = 1e-6) -> CovarianceKoopmanModel:
+        r""" Estimates a :class:`CovarianceKoopmanModel` directly from time-series data using the :class:`Covariance`
+        estimator. For parameters `dim`, `scaling`, `epsilon`.
+
+        Parameters
+        ----------
+        data : (T, n) ndarray or list thereof
+            Input time-series.
+        lagtime : int
+            Lagtime for covariance matrix estimation, must be positive.
+        scaling
+            Please see :meth:`__init__`.
+        dim
+            Please see :meth:`__init__`.
+        epsilon
+            Please see :meth:`__init__`.
+
+        Returns
+        -------
+        model : CovarianceKoopmanModel
+            The estimated model.
+        """
+        covar = VAMP.covariance_estimator(lagtime=lagtime)
         covariances = covar.fit(data).fetch_model()
-        estimator = VAMP(lagtime, dim, scaling, epsilon, ncov)
+        estimator = VAMP(dim, scaling, epsilon)
         return estimator.fit(covariances).fetch_model()
 
     @property
@@ -700,18 +268,6 @@ class VAMP(Estimator, Transformer):
     @epsilon.setter
     def epsilon(self, value):
         self._epsilon = value
-
-    @property
-    def right(self) -> bool:
-        r""" Whether to use right singular functions instead of left singular functions.
-
-        :type: bool
-        """
-        return self._right
-
-    @right.setter
-    def right(self, value: bool):
-        self._right = value
 
     @property
     def scaling(self) -> Optional[str]:
@@ -760,12 +316,14 @@ class VAMP(Estimator, Transformer):
         self._dim = value
 
     def fit(self, data, **kw):
-        r""" Fits a new :class:`VAMPModel` which can be obtained by a subsequent call to :meth:`fetch_model`.
+        r""" Fits a new :class:`CovarianceKoopmanModel` which can be obtained by a
+        subsequent call to :meth:`fetch_model`.
 
         Parameters
         ----------
-        data : (T, d) ndarray
-            Input timeseries. If presented with multiple trajectories, :meth:`partial_fit` should be used.
+        data : CovarianceModel
+            Covariance matrices :math:`C_{00}, C_{0t}, C_{tt}` in form of a CovarianceModel instance. If the model
+            should be fitted directly from data, please see :meth:`from_data`.
         **kw
             Ignored keyword arguments for scikit-learn compatibility.
 
@@ -779,20 +337,22 @@ class VAMP(Estimator, Transformer):
             operator=np.diag(decomposition.singular_values),
             basis_transform_forward=KoopmanBasisTransform(data.mean_0, decomposition.left_singular_vecs),
             basis_transform_backward=KoopmanBasisTransform(data.mean_t, decomposition.right_singular_vecs),
-            cov=self.covariances, scaling=self.scaling, epsilon=self.epsilon
+            rank_0=decomposition.rank0, rank_t=decomposition.rankt,
+            dim=self.dim, cov=data, scaling=self.scaling, epsilon=self.epsilon
         )
         return self
 
-    def transform(self, data, right=None):
+    def transform(self, data, forward=True):
         r""" Projects given timeseries onto dominant singular functions. This method dispatches to
-        :meth:`VAMPModel.transform`.
+        :meth:`CovarianceKoopmanModel.transform`.
 
         Parameters
         ----------
         data : (T, n) ndarray
             Input timeseries data.
-        right : bool or None, optional, default=None
-            Whether to use left or right eigenvectors for projection, overrides :attr:`right` if not None.
+        forward : bool, default=True
+            Whether to use left or right eigenvectors for projection. Left corresponds to `forward == True`, right
+            corresponds to `forward == False`.
 
         Returns
         -------
@@ -801,28 +361,14 @@ class VAMP(Estimator, Transformer):
             If `right` is True, projection will be on the right singular functions. Otherwise, projection will be on
             the left singular functions.
         """
-        return self.fetch_model().transform(data, right=right)
+        return self.fetch_model().transform(data, forward=forward)
 
     def fetch_model(self) -> CovarianceKoopmanModel:
-        r""" Finalizes current model and yields new :class:`VAMPModel`.
+        r""" Finalizes current model and yields new :class:`CovarianceKoopmanModel`.
 
         Returns
         -------
-        model : VAMPModel
+        model : CovarianceKoopmanModel
             The estimated model.
         """
         return self._model
-
-    @property
-    def lagtime(self) -> int:
-        r""" Lagtime at which to compute covariances.
-
-        :getter: Yields currently configured lagtime.
-        :setter: Configures a new lagtime.
-        :type: int
-        """
-        return self._covar.lagtime
-
-    @lagtime.setter
-    def lagtime(self, value: int):
-        self._covar.lagtime = value

--- a/sktime/markov/__init__.py
+++ b/sktime/markov/__init__.py
@@ -7,7 +7,7 @@ Transition counting and analysis tools
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     pcca
     PCCAModel

--- a/sktime/markov/hmm/__init__.py
+++ b/sktime/markov/hmm/__init__.py
@@ -9,7 +9,7 @@ Output models
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     OutputModel
     DiscreteOutputModel
@@ -38,7 +38,7 @@ steps are involved:
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     init.discrete.metastable_from_data
     init.discrete.metastable_from_msm
@@ -48,7 +48,7 @@ uniform, and drawing a random row-stochastic emission probability matrix:
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     init.discrete.random_guess
 
@@ -57,7 +57,7 @@ model is estimated. This particular heuristic requires an installation of `sciki
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     init.gaussian.from_data
 
@@ -65,7 +65,7 @@ Estimation and resulting model:
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     MaximumLikelihoodHMSM
     HiddenMarkovStateModel
@@ -80,7 +80,7 @@ sampling to sample from Bayesian hidden Markov model posteriors.
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     BayesianHMSM
     BayesianHMMPosterior

--- a/sktime/markov/msm/__init__.py
+++ b/sktime/markov/msm/__init__.py
@@ -5,7 +5,7 @@ Maximum-likelihood MSMs (ML-MSM) and Bayesian sampling
 ------------------------------------------------------
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     MaximumLikelihoodMSM
     MarkovStateModel
@@ -18,7 +18,7 @@ Observable operator model MSMs (OOMs)
 -------------------------------------
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     OOMReweightedMSM
     KoopmanReweightedMSM
@@ -27,7 +27,7 @@ Augmented markov models (AMMs)
 ------------------------------
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     AugmentedMSMEstimator
     AugmentedMSM

--- a/sktime/markov/msm/markov_state_model.py
+++ b/sktime/markov/msm/markov_state_model.py
@@ -44,14 +44,14 @@ class MarkovStateModel(Model):
     BayesianMSM : bayesian sampling of MSMs to obtain uncertainties
     """
 
-    def __init__(self, transition_matrix: np.ndarray, stationary_distribution=None, reversible=None,
+    def __init__(self, transition_matrix, stationary_distribution=None, reversible=None,
                  n_eigenvalues=None, ncv=None, count_model=None, transition_matrix_tolerance=1e-8):
         r"""
         Constructs a new markov state model based on a transition matrix.
 
         Parameters
         ----------
-        transition_matrix : (n,n) ndarray
+        transition_matrix : (n,n) array_like
             The transition matrix.
         stationary_distribution : ndarray(n), optional, default=None
             Stationary distribution. Can be optionally given in case if it was already computed.

--- a/sktime/numeric/__init__.py
+++ b/sktime/numeric/__init__.py
@@ -7,7 +7,7 @@ General numerical tools
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     mdot
     is_diagonal_matrix
@@ -18,7 +18,7 @@ Numerical tools for eigenvalue problems
 
 .. autosummary::
     :toctree: generated/
-    :template: base_nomodule.rst
+    :template: class_nomodule.rst
 
     eig_corr
     sort_by_norm

--- a/sktime/numeric/__init__.py
+++ b/sktime/numeric/__init__.py
@@ -10,6 +10,7 @@ General numerical tools
     :template: base_nomodule.rst
 
     mdot
+    is_diagonal_matrix
 
 ===============================================================================
 Numerical tools for eigenvalue problems
@@ -29,6 +30,6 @@ Numerical tools for eigenvalue problems
 
 """
 
-from .utils import mdot
+from .utils import mdot, is_diagonal_matrix
 from .eigen import eig_corr, sort_by_norm, spd_eig, spd_inv, spd_inv_split, spd_inv_sqrt, ZeroRankError
 

--- a/sktime/numeric/utils.py
+++ b/sktime/numeric/utils.py
@@ -1,5 +1,6 @@
 import numpy as _np
 
+
 def mdot(*args):
     """Computes a matrix product of multiple ndarrays
 
@@ -24,3 +25,19 @@ def mdot(*args):
         except ValueError as ve:
             raise ValueError(f'argument {i} and {i + 1} are not shape compatible:\n{ve}')
     return x
+
+
+def is_diagonal_matrix(matrix: _np.ndarray) -> bool:
+    r""" Checks whether a provided matrix is a diagonal matrix, i.e., :math:`A = \mathrm{diag}(a_1,\ldots,\a_n)`.
+
+    Parameters
+    ----------
+    matrix : ndarray
+        The matrix for which this check is performed.
+
+    Returns
+    -------
+    is_diagonal : bool
+        True if the matrix is a diagonal matrix, otherwise False.
+    """
+    return _np.all(matrix == _np.diag(_np.diagonal(matrix)))

--- a/tests/base/test_sklearn_compat.py
+++ b/tests/base/test_sklearn_compat.py
@@ -25,11 +25,11 @@ class TestSkLearnCompat(unittest.TestCase):
             transition_matrix = fh['transition_matrix']
 
         pipeline = Pipeline(steps=[
-            ('tica', tica.TICA(lagtime=1, dim=1)),
+            ('tica', tica.TICA(dim=1)),
             ('cluster', kmeans.KmeansClustering(n_clusters=2, max_iter=500)),
             ('counts', TransitionCountEstimator(lagtime=1, count_mode="sliding"))
         ])
-        pipeline.fit(data)
+        pipeline.fit(data, tica__lagtime=1)
         counts = pipeline[-1].fetch_model().submodel_largest()
         mlmsm = msm.MaximumLikelihoodMSM().fit(counts).fetch_model()
         P = mlmsm.pcca(2).coarse_grained_transition_matrix

--- a/tests/decomposition/test_koopman_reweighting.py
+++ b/tests/decomposition/test_koopman_reweighting.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import pkg_resources
 
-from sktime.covariance import KoopmanModel
+from sktime.covariance import KoopmanWeightingModel
 from sktime.data.util import timeshifted_split
 from sktime.numeric.eigen import sort_by_norm
 import numpy.linalg as scl
@@ -114,8 +114,8 @@ class TestKoopmanTICA(unittest.TestCase):
         u_input = np.zeros(N + 1)
         u_input[0:N] = cls.R.dot(u_mod[0:-1])  # in input basis
         u_input[N] = u_mod[-1] - cls.mean_x.dot(cls.R.dot(u_mod[0:-1]))
-        cls.weight_obj = KoopmanModel(u=u_input[:-1], u_const=u_input[-1], koopman_operator=cls.K,
-                                      whitening_transformation=cls.R, covariances=None)
+        cls.weight_obj = KoopmanWeightingModel(u=u_input[:-1], u_const=u_input[-1], koopman_operator=cls.K,
+                                               whitening_transformation=cls.R, covariances=None)
 
         # Compute weights over all data points:
         cls.wtraj = []
@@ -203,8 +203,8 @@ class TestKoopmanTICA(unittest.TestCase):
         np.testing.assert_allclose(out_traj_eq, ev_traj_eq)
 
     def test_koopman_estimator_partial_fit(self):
-        from sktime.covariance import KoopmanEstimator
-        est = KoopmanEstimator(lagtime=self.tau)
+        from sktime.covariance import KoopmanWeightingEstimator
+        est = KoopmanWeightingEstimator(lagtime=self.tau)
         data_lagged = timeshifted_split(self.data, lagtime=self.tau, n_splits=10)
         for traj in data_lagged:
             est.partial_fit(traj)
@@ -214,8 +214,8 @@ class TestKoopmanTICA(unittest.TestCase):
         np.testing.assert_allclose(m.const_weight_input, self.weight_obj.const_weight_input)
 
     def test_koopman_estimator_fit(self):
-        from sktime.covariance import KoopmanEstimator
-        est = KoopmanEstimator(lagtime=self.tau)
+        from sktime.covariance import KoopmanWeightingEstimator
+        est = KoopmanWeightingEstimator(lagtime=self.tau)
         est.fit(self.data)
         m = est.fetch_model()
 

--- a/tests/decomposition/test_koopman_reweighting.py
+++ b/tests/decomposition/test_koopman_reweighting.py
@@ -162,9 +162,7 @@ class TestKoopmanTICA(unittest.TestCase):
 
         def tica(data, lag, weights=None, **params):
             from sktime.decomposition.tica import TICA
-            t = TICA(lagtime=lag, **params)
-            t.fit(data, weights=weights)
-            return t.fetch_model()
+            return TICA.from_data(data, lagtime=lag, weights=weights, dim=0.95, **params)
 
         # Set up the model:
         cls.koop_rev = tica(cls.data, lag=cls.tau, scaling=None)
@@ -183,14 +181,14 @@ class TestKoopmanTICA(unittest.TestCase):
         np.testing.assert_allclose(self.koop_eq.cov_0t, self.Ct_eq)
 
     def test_eigenvalues(self):
-        np.testing.assert_allclose(self.koop_rev.eigenvalues, self.ls)
-        np.testing.assert_allclose(self.koop_eq.eigenvalues, self.lr)
+        np.testing.assert_allclose(self.koop_rev.singular_values, self.ls)
+        np.testing.assert_allclose(self.koop_eq.singular_values, self.lr)
         np.testing.assert_allclose(self.koop_rev.timescales(self.tau), self.tss)
         np.testing.assert_allclose(self.koop_eq.timescales(self.tau), self.tsr)
 
     def test_eigenvectors(self):
-        np.testing.assert_allclose(self.koop_rev.eigenvectors, self.Rs)
-        np.testing.assert_allclose(self.koop_eq.eigenvectors, self.Rr)
+        np.testing.assert_allclose(self.koop_rev.singular_vectors_left, self.Rs)
+        np.testing.assert_allclose(self.koop_eq.singular_vectors_left, self.Rr)
 
     def test_transform(self):
         traj = self.data[0] - self.mean_rev[None, :]

--- a/tests/decomposition/test_koopman_reweighting.py
+++ b/tests/decomposition/test_koopman_reweighting.py
@@ -162,7 +162,7 @@ class TestKoopmanTICA(unittest.TestCase):
 
         def tica(data, lag, weights=None, **params):
             from sktime.decomposition.tica import TICA
-            return TICA.from_data(data, lagtime=lag, weights=weights, dim=0.95, **params)
+            return TICA(dim=0.95, **params).fit_from_timeseries(data, lagtime=lag, weights=weights).fetch_model()
 
         # Set up the model:
         cls.koop_rev = tica(cls.data, lag=cls.tau, scaling=None)

--- a/tests/decomposition/test_tica.py
+++ b/tests/decomposition/test_tica.py
@@ -40,12 +40,11 @@ class TestTICA(unittest.TestCase):
         np.random.seed(0)
         data = np.random.randn(23000, 3)
 
-        est = TICA(lagtime=lag, dim=1)
-        for X, Y in timeshifted_split(data, lagtime=lag, chunksize=chunk):
-            est.partial_fit((X, Y))
-        model1 = est.fetch_model().copy()
+        model1 = TICA.from_data(data, lagtime=lag, dim=1)
         # ------- run again with new chunksize -------
-        est.fit(data)
+        covars = TICA.covariance_estimator(lagtime=lag).fit(data).fetch_model()
+        est = TICA(dim=1)
+        est.fit(covars)
         model2 = est.fetch_model().copy()
 
         assert model1 != model2

--- a/tests/markov/msm/test_mlmsm.py
+++ b/tests/markov/msm/test_mlmsm.py
@@ -374,3 +374,12 @@ def test_raises_disconnected(disconnected_states, lag, count_mode):
     submodel = count_model.submodel(fully_disconnected_set)
     with assert_raises(AssertionError):
         MaximumLikelihoodMSM(reversible=True).fit(submodel)
+
+
+def test_nonreversible_disconnected():
+    msm1 = MarkovStateModel([[.7, .3], [.3, .7]])
+    msm2 = MarkovStateModel([[.9, .05, .05], [.3, .6, .1], [.1, .1, .8]])
+    traj = np.concatenate([msm1.simulate(10000), 2 + msm2.simulate(10000)])
+    counts = TransitionCountEstimator(lagtime=1, count_mode="sliding").fit(traj).fetch_model()
+    msm = MaximumLikelihoodMSM(reversible=False).fit(counts).fetch_model()
+    print(msm.transition_matrix)

--- a/tests/numeric/test_utils.py
+++ b/tests/numeric/test_utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+from numpy.testing import *
+
+from sktime.numeric import is_diagonal_matrix, mdot
+
+
+def test_is_diagonal_matrix():
+    assert_(is_diagonal_matrix(np.diag([1, 2, 3, 4, 5])))
+    assert_(not is_diagonal_matrix(np.array([[1, 2], [3, 4]])))
+
+
+def test_mdot():
+    A = np.random.normal(size=(5, 10))
+    B = np.random.normal(size=(10, 20))
+    C = np.random.normal(size=(20, 30))
+    assert_almost_equal(mdot(A, B, C), A @ B @ C)


### PR DESCRIPTION
created a hierarchy of Koopman models so that also TICA can be integrated in a second PR. Fixed documentation where appropriate.
VAMP is now estimated by a covariance model, but has a static `from_data` method.