### PR TITLE
[MNT] remove shellcheck from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,11 +59,3 @@ repos:
     hooks:
       - id: pydocstyle
         args: ["--config=setup.cfg"]
-
-  # We use the Python version instead of the original version which seems to require Docker
-  # https://github.com/koalaman/shellcheck-precommit
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
-    hooks:
-      - id: shellcheck
-        name: shellcheck


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/sktime/sktime/blob/main/CONTRIBUTING.md
-->

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

I'm removing `shellcheck` from precommit check since it causes problems when a python version is not compiled with a bunch of optional modules. This is a frustration when working with python from `pyenv` since shellcheck itself fails requiring `readlines`.
Shellcheck is only linting/checking shell scripts and there a few of those that almost never change and are rarely used so it is not critical.

#### Does your contribution introduce a new dependency? If yes, which one?
NO