### PR TITLE
[ENH] kNN Classifier and Regressor reimplementations

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2062,6 +2062,15 @@
       "contributions": [
         "maintenance"
       ]
-    }
+    },
+    {
+        "login": "GuiArcencio",
+        "name": "Guilherme Arcencio",
+        "avatar_url": "https://avatars.githubusercontent.com/u/47733489",
+        "profile": "https://github.com/GuiArcencio",
+        "contributions": [
+          "code"
+        ]
+      }
   ]
 }

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""KNN time series regression.
+"""KNN time series classification.
 
 This class is a KNN classifier which supports time series distance measures.
 The class has hardcoded string references to numba based distances in sktime.distances.
@@ -36,15 +36,13 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         distance measure between time series
         if str, must be one of the following strings:
             'euclidean', 'squared', 'dtw', 'ddtw', 'wdtw', 'wddtw',
-            'lcss', 'edr', 'erp', 'msm'
+            'lcss', 'edr', 'erp', 'msm', 'twe'
         this will substitute a hard-coded distance metric from sktime.distances
         When mpdist is used, the subsequence length (parameter m) must be set
             Example: knn_mpdist = KNeighborsTimeSeriesClassifier(
                                 metric='mpdist', metric_params={'m':30})
-        if callable, must be of signature (X: Panel, X2: Panel) -> np.ndarray
-            output must be mxn array if X is Panel of m Series, X2 of n Series
-            if distance_mtype is not set, must be able to take
-                X, X2 which are pd_multiindex and numpy3D mtype
+        if callable, must be of signature (X: np.ndarray, X2: np.ndarray) -> np.ndarray
+            output must be mxn array if X is array of m Series, X2 of n Series
         can be pairwise panel transformer inheriting from BasePairwiseTransformerPanel
     distance_params : dict, optional. default = None.
         dictionary for metric parameters , in case that distance is a str
@@ -58,10 +56,10 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
     Examples
     --------
     >>> from sktime.datasets import load_unit_test
-    >>> from sktime.regression.distance_based import KNeighborsTimeSeriesClassifier
+    >>> from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
     >>> X_train, y_train = load_unit_test(return_X_y=True, split="train")
     >>> X_test, y_test = load_unit_test(return_X_y=True, split="test")
-    >>> classifier = KNeighborsTimeSeriesClassifier()
+    >>> classifier = KNeighborsTimeSeriesClassifier(distance="euclidean")
     >>> classifier.fit(X_train, y_train)
     KNeighborsTimeSeriesClassifier(...)
     >>> y_pred = classifier.predict(X_test)

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -205,3 +205,30 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             raise Exception(f"Invalid kNN weights: {self.weights}")
 
         return closest_idx, ws
+
+    @classmethod
+    def get_test_params(cls, parameter_set="default"):
+        """Return testing parameter settings for the estimator.
+
+        Parameters
+        ----------
+        parameter_set : str, default="default"
+            Name of the set of test parameters to return, for use in tests. If no
+            special parameters are defined for a value, will return `"default"` set.
+            For classifiers, a "default" set of parameters should be provided for
+            general testing, and a "results_comparison" set for comparing against
+            previously recorded results if the general set does not produce suitable
+            probabilities to compare against.
+
+        Returns
+        -------
+        params : dict or list of dict, default={}
+            Parameters to create testing instances of the class.
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`.
+        """
+        # non-default distance and algorithm
+        params1 = {"distance": "euclidean"}
+
+        return [params1]

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -7,17 +7,15 @@ It can also be used with callables, or sktime (pairwise transformer) estimators.
 """
 
 __author__ = ["TonyBagnall", "GuiArcencio"]
-__all__ = ["KNeighborsTimeSeriesRegressor"]
+__all__ = ["KNeighborsTimeSeriesClassifier"]
 
 import numpy as np
 
-from sktime.distances import distance_factory
 from sktime.classification.base import BaseClassifier
+from sktime.distances import distance_factory
 
-WEIGHTS_SUPPORTED = [
-    "uniform",
-    "distance"
-]
+WEIGHTS_SUPPORTED = ["uniform", "distance"]
+
 
 class KNeighborsTimeSeriesClassifier(BaseClassifier):
     """KNN Time Series Classifier.
@@ -80,7 +78,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         distance_params=None,
         n_neighbors=1,
         weights="uniform",
-        n_jobs=1
+        n_jobs=1,
     ):
         self.distance = distance
         self.distance_params = distance_params
@@ -164,11 +162,11 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             for id, w in zip(idx, weights):
                 predicted_class = self.y_[id]
                 scores[predicted_class] += w
-            
+
             preds[i] = self.classes_[np.argmax(scores)]
 
         return preds
-    
+
     def _kneighbors(self, X):
         """Find the K-neighbors of a point.
 
@@ -185,7 +183,6 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
         ws : array
             Array representing the weights of each neighbor.
         """
-        
         distances = np.array(
             [self.metric_(X, self.X_[j]) for j in range(self.X_.shape[0])]
         )
@@ -205,7 +202,7 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
             # Using epsilon ~= 0 to avoid division by zero
             ws = 1 / (ws + np.finfo(float).eps)
         elif self.weights == "uniform":
-            ws = np.repeat(1., self.n_neighbors)
+            ws = np.repeat(1.0, self.n_neighbors)
         else:
             raise Exception(f"Invalid kNN weights: {self.weights}")
 

--- a/sktime/classification/distance_based/_time_series_neighbors.py
+++ b/sktime/classification/distance_based/_time_series_neighbors.py
@@ -1,55 +1,28 @@
 # -*- coding: utf-8 -*-
-"""KNN time series classification.
+"""KNN time series regression.
 
 This class is a KNN classifier which supports time series distance measures.
 The class has hardcoded string references to numba based distances in sktime.distances.
 It can also be used with callables, or sktime (pairwise transformer) estimators.
-
-This is a direct wrap or sklearn KNeighbors, with added functionality that allows
-time series distances to be passed, and the sktime time series classifier interface.
-
-todo: add a utility method to set keyword args for distance measure parameters.
-(e.g.  handle the parameter name(s) that are passed as metric_params automatically,
-depending on what distance measure is used in the classifier (e.g. know that it is w
-for dtw, c for msm, etc.). Also allow long-format specification for
-non-standard/user-defined measures e.g. set_distance_params(measure_type=None,
-param_values_to_set=None,
-param_names=None)
 """
 
-__author__ = ["jasonlines", "TonyBagnall", "chrisholder", "fkiraly"]
-__all__ = ["KNeighborsTimeSeriesClassifier"]
-
-from inspect import signature
+__author__ = ["TonyBagnall", "GuiArcencio"]
+__all__ = ["KNeighborsTimeSeriesRegressor"]
 
 import numpy as np
-from sklearn.neighbors import KNeighborsClassifier
 
+from sktime.distances import distance_factory
 from sktime.classification.base import BaseClassifier
-from sktime.datatypes import check_is_mtype
-from sktime.distances import pairwise_distance
 
-# add new distance string codes here
-DISTANCES_SUPPORTED = [
-    "euclidean",
-    # Euclidean will default to the base class distance
-    "squared",
-    "dtw",
-    "ddtw",
-    "wdtw",
-    "wddtw",
-    "lcss",
-    "edr",
-    "erp",
-    "msm",
-    "twe",
+WEIGHTS_SUPPORTED = [
+    "uniform",
+    "distance"
 ]
-
 
 class KNeighborsTimeSeriesClassifier(BaseClassifier):
     """KNN Time Series Classifier.
 
-    An adapted version of the scikit-learn KNeighborsClassifier for time series data.
+    An adapted K-Neighbors Classifier for time series data.
 
     This class is a KNN classifier which supports time series distance measures.
     It has hardcoded string references to numba based distances in sktime.distances,
@@ -58,60 +31,39 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
     Parameters
     ----------
     n_neighbors : int, set k for knn (default =1)
-    weights : {'uniform', 'distance'} or callable, default='uniform'
-        Weight function used in prediction.  Possible values:
-        - 'uniform' : uniform weights.  All points in each neighborhood
-          are weighted equally.
-        - 'distance' : weight points by the inverse of their distance.
-          in this case, closer neighbors of a query point will have a
-          greater influence than neighbors which are further away.
-        - [callable] : a user-defined function which accepts an
-          array of distances, and returns an array of the same shape
-          containing the weights.
-    algorithm : str, optional. default = 'brute'
-        search method for neighbours
-        one of {'auto’, 'ball_tree', 'kd_tree', 'brute'}
+    weights : string or callable function, optional. default = 'uniform'
+        mechanism for weighting a vot
+        one of: 'uniform', 'distance', or a callable function
     distance : str or callable, optional. default ='dtw'
         distance measure between time series
         if str, must be one of the following strings:
             'euclidean', 'squared', 'dtw', 'ddtw', 'wdtw', 'wddtw',
-            'lcss', 'edr', 'erp', 'msm', 'twe'
+            'lcss', 'edr', 'erp', 'msm'
         this will substitute a hard-coded distance metric from sktime.distances
-        If non-class callable, parameters can be passed via distance_params
-            Example: knn_dtw = KNeighborsTimeSeriesClassifier(
-                                    distance='dtw', distance_params={'epsilon':0.1})
-        if any callable, must be of signature (X: Panel, X2: Panel) -> np.ndarray
+        When mpdist is used, the subsequence length (parameter m) must be set
+            Example: knn_mpdist = KNeighborsTimeSeriesClassifier(
+                                metric='mpdist', metric_params={'m':30})
+        if callable, must be of signature (X: Panel, X2: Panel) -> np.ndarray
             output must be mxn array if X is Panel of m Series, X2 of n Series
             if distance_mtype is not set, must be able to take
                 X, X2 which are pd_multiindex and numpy3D mtype
         can be pairwise panel transformer inheriting from BasePairwiseTransformerPanel
     distance_params : dict, optional. default = None.
-        dictionary for distance parameters, in case that distance is a str or callable
-    distance_mtype : str, or list of str optional. default = None.
-        mtype that distance expects for X and X2, if a callable
-            only set this if distance is not BasePairwiseTransformerPanel descendant
-    pass_train_distances : bool, optional, default = False.
-        Whether distances between training points are computed and passed to sklearn.
-        Passing is superfluous for algorithm='brute', but may have impact otherwise.
-    leaf_size : int, default=30
-        Leaf size passed to BallTree or KDTree.  This can affect the
-        speed of the construction and query, as well as the memory
-        required to store the tree.  The optimal value depends on the
-        nature of the problem.
+        dictionary for metric parameters , in case that distance is a str
     n_jobs : int, default=None
         The number of parallel jobs to run for neighbors search.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See :term:`Glossary <n_jobs>`
         for more details.
-        Doesn't affect :meth:`fit` method.
+        Parameter for compatibility purposes, still unimplemented.
 
     Examples
     --------
-    >>> from sktime.classification.distance_based import KNeighborsTimeSeriesClassifier
     >>> from sktime.datasets import load_unit_test
+    >>> from sktime.regression.distance_based import KNeighborsTimeSeriesClassifier
     >>> X_train, y_train = load_unit_test(return_X_y=True, split="train")
     >>> X_test, y_test = load_unit_test(return_X_y=True, split="test")
-    >>> classifier = KNeighborsTimeSeriesClassifier(distance="euclidean")
+    >>> classifier = KNeighborsTimeSeriesClassifier()
     >>> classifier.fit(X_train, y_train)
     KNeighborsTimeSeriesClassifier(...)
     >>> y_pred = classifier.predict(X_test)
@@ -119,236 +71,142 @@ class KNeighborsTimeSeriesClassifier(BaseClassifier):
 
     _tags = {
         "capability:multivariate": True,
-        "capability:unequal_length": True,
-        "capability:missing_values": True,
-        "X_inner_mtype": ["pd-multiindex", "numpy3D"],
-        "classifier_type": "distance",
+        "X_inner_mtype": ["numpy3D"],
     }
 
     def __init__(
         self,
-        n_neighbors=1,
-        weights="uniform",
-        algorithm="brute",
         distance="dtw",
         distance_params=None,
-        distance_mtype=None,
-        pass_train_distances=False,
-        leaf_size=30,
-        n_jobs=None,
+        n_neighbors=1,
+        weights="uniform",
+        n_jobs=1
     ):
-        self.n_neighbors = n_neighbors
-        self.weights = weights
-        self.algorithm = algorithm
         self.distance = distance
         self.distance_params = distance_params
-        self.distance_mtype = distance_mtype
-        self.pass_train_distances = pass_train_distances
-        self.leaf_size = leaf_size
+        self.n_neighbors = n_neighbors
         self.n_jobs = n_jobs
 
-        super(KNeighborsTimeSeriesClassifier, self).__init__()
-
-        # input check for supported distance strings
-        if isinstance(distance, str) and distance not in DISTANCES_SUPPORTED:
+        if weights not in WEIGHTS_SUPPORTED:
             raise ValueError(
-                f"Unrecognised distance measure string: {distance}. "
-                f"Allowed values for string codes are: {DISTANCES_SUPPORTED}. "
-                "Alternatively, pass a callable distance measure into the constuctor."
+                f"Unrecognised kNN weights: {weights}. "
+                f"Allowed values are: {WEIGHTS_SUPPORTED}. "
             )
+        self.weights = weights
 
-        self.knn_estimator_ = KNeighborsClassifier(
-            n_neighbors=n_neighbors,
-            algorithm=algorithm,
-            metric="precomputed",
-            metric_params=distance_params,
-            leaf_size=leaf_size,
-            n_jobs=n_jobs,
-            weights=weights,
-        )
-
-        # the distances in sktime.distances want numpy3D
-        #   otherwise all Panel formats are ok
-        if isinstance(distance, str):
-            self.set_tags(X_inner_mtype="numpy3D")
-            self.set_tags(**{"capability:unequal_length": False})
-            self.set_tags(**{"capability:missing_values": False})
-        elif distance_mtype is not None:
-            self.set_tags(X_inner_mtype=distance_mtype)
-
-        from sktime.dists_kernels import BasePairwiseTransformerPanel
-
-        # inherit capability tags from distance, if it is an estimator
-        if isinstance(distance, BasePairwiseTransformerPanel):
-            inherit_tags = [
-                "capability:missing_values",
-                "capability:unequal_length",
-                "capability:multivariate",
-            ]
-            self.clone_tags(distance, inherit_tags)
-
-    def _distance(self, X, X2=None):
-        """Compute distance - unified interface to str code and callable."""
-        distance = self.distance
-        distance_params = self.distance_params
-        if distance_params is None:
-            distance_params = {}
-
-        if isinstance(distance, str):
-            return pairwise_distance(X, X2, distance, **distance_params)
-        else:
-            if X2 is not None:
-                return distance(X, X2, **distance_params)
-            # if X2 is None, check if distance allows None X2 to mean "X2=X"
-            else:
-                sig = signature(distance).parameters
-                X2_sig = sig[list(sig.keys())[1]]
-                if X2_sig.default is not None:
-                    return distance(X, X2, **distance_params)
-                else:
-                    return distance(X, **distance_params)
+        super(KNeighborsTimeSeriesClassifier, self).__init__()
 
     def _fit(self, X, y):
         """Fit the model using X as training data and y as target values.
 
         Parameters
         ----------
-        X : sktime comatible Panel data container, of mtype X_inner_mtype, with n series
-            data to fit the estimator to
+        X : sktime-compatible Panel data format, with n_samples series
         y : {array-like, sparse matrix}
-            Target values of shape = [n]
+            Class labels of shape = [n_samples]
         """
-        # store full data as indexed X
-        self._X = X
+        if isinstance(self.distance, str):
+            if self.distance_params is None:
+                self.metric_ = distance_factory(X[0], X[0], metric=self.distance)
+            else:
+                self.metric_ = distance_factory(
+                    X[0], X[0], metric=self.distance, **self.distance_params
+                )
 
-        if self.pass_train_distances:
-            dist_mat = self._distance(X)
-        else:
-            # if we do not want/need to pass train-train distances,
-            #   we still need to pass a zeros matrix, this means "do not consider"
-            # citing the sklearn KNeighborsClassifier docs on distance matrix input:
-            # "X may be a sparse graph, in which case only “nonzero” elements
-            #   may be considered neighbors."
-            X_inner_mtype = self.get_tag("X_inner_mtype")
-            _, _, X_meta = check_is_mtype(X, X_inner_mtype, return_metadata=True)
-            n = X_meta["n_instances"]
-            dist_mat = np.zeros([n, n], dtype="float")
-
-        self.knn_estimator_.fit(dist_mat, y)
-
+        self.X_ = X
+        self.classes_, self.y_ = np.unique(y, return_inverse=True)
         return self
 
-    def kneighbors(self, X, n_neighbors=None, return_distance=True):
-        """Find the K-neighbors of a point.
-
-        Returns indices of and distances to the neighbors of each point.
+    def _predict_proba(self, X):
+        """Return probability estimates for the provided data.
 
         Parameters
         ----------
-        X : sktime-compatible data format, Panel or Series, with n_samples series
-        n_neighbors : int
-            Number of neighbors to get (default is the value
-            passed to the constructor).
-        return_distance : boolean, optional. Defaults to True.
-            If False, distances will not be returned
+        X : sktime-compatible Panel data format, with n_samples series
 
         Returns
         -------
-        dist : array
-            Array representing the lengths to points, only present if
-            return_distance=True
-        ind : array
-            Indices of the nearest points in the population matrix.
+        p : array of shape = [n_samples, n_classes]
+            The class probabilities of the input samples. Classes are ordered
+            by lexicographic order.
         """
         self.check_is_fitted()
 
-        # boilerplate input checks for predict-like methods
-        X = self._check_convert_X_for_predict(X)
+        preds = np.zeros((X.shape[0], len(self.classes_)))
+        for i in range(X.shape[0]):
+            idx, weights = self._kneighbors(X[i])
+            for id, w in zip(idx, weights):
+                predicted_class = self.y_[id]
+                preds[i, predicted_class] += w
 
-        # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
+            preds[i] = preds[i] / np.sum(preds[i])
 
-        result = self.knn_estimator_.kneighbors(
-            dist_mat, n_neighbors=n_neighbors, return_distance=return_distance
-        )
-
-        # result is either dist, or (dist, ind) pair, depending on return_distance
-        return result
+        return preds
 
     def _predict(self, X):
         """Predict the class labels for the provided data.
 
         Parameters
         ----------
-        X : sktime-compatible Panel data, of mtype X_inner_mtype, with n_samples series
-            data to predict class labels for
+        X : sktime-compatible Panel data format, with n_samples series
 
         Returns
         -------
         y : array of shape [n_samples] or [n_samples, n_outputs]
             Class labels for each data sample.
         """
-        # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
+        self.check_is_fitted()
 
-        y_pred = self.knn_estimator_.predict(dist_mat)
+        preds = np.empty(X.shape[0], dtype=self.classes_.dtype)
+        for i in range(X.shape[0]):
+            scores = np.zeros(len(self.classes_))
+            idx, weights = self._kneighbors(X[i])
+            for id, w in zip(idx, weights):
+                predicted_class = self.y_[id]
+                scores[predicted_class] += w
+            
+            preds[i] = self.classes_[np.argmax(scores)]
 
-        return y_pred
+        return preds
+    
+    def _kneighbors(self, X):
+        """Find the K-neighbors of a point.
 
-    def _predict_proba(self, X):
-        """Return probability estimates for the test data X.
-
-        Parameters
-        ----------
-        X : sktime-compatible Panel data, of mtype X_inner_mtype, with n_samples series
-            data to predict class labels for
-
-        Returns
-        -------
-        p : array of shape = [n_samples, n_classes], or a list of n_outputs
-            of such arrays if n_outputs > 1.
-            The class probabilities of the input samples. Classes are ordered
-            by lexicographic order.
-        """
-        # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
-
-        y_pred = self.knn_estimator_.predict_proba(dist_mat)
-
-        return y_pred
-
-    @classmethod
-    def get_test_params(cls, parameter_set="default"):
-        """Return testing parameter settings for the estimator.
+        Returns indices and weights of each point.
 
         Parameters
         ----------
-        parameter_set : str, default="default"
-            Name of the set of test parameters to return, for use in tests. If no
-            special parameters are defined for a value, will return `"default"` set.
-            For classifiers, a "default" set of parameters should be provided for
-            general testing, and a "results_comparison" set for comparing against
-            previously recorded results if the general set does not produce suitable
-            probabilities to compare against.
+        X : sktime-compatible data format, Panel or Series, with n_samples series
 
         Returns
         -------
-        params : dict or list of dict, default={}
-            Parameters to create testing instances of the class.
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
-            `create_test_instance` uses the first (or only) dictionary in `params`.
+        ind : array
+            Indices of the nearest points in the population matrix.
+        ws : array
+            Array representing the weights of each neighbor.
         """
-        # non-default distance and algorithm
-        params1 = {"distance": "euclidean"}
+        
+        distances = np.array(
+            [self.metric_(X, self.X_[j]) for j in range(self.X_.shape[0])]
+        )
 
-        # testing distance_params
-        params2 = {"distance": "dtw", "distance_params": {"epsilon": 0.1}}
+        # Find indices of k nearest neighbors using partitioning:
+        # [0..k-1], [k], [k+1..n-1]
+        # They might not be ordered within themselves,
+        # but it is not necessary and partitioning is
+        # O(n) while sorting is O(nlogn)
+        closest_idx = np.argpartition(distances, self.n_neighbors)
+        closest_idx = closest_idx[: self.n_neighbors]
 
-        # testing that callables/classes can be passed
-        from sktime.dists_kernels.compose_tab_to_panel import AggrDist
+        if self.weights == "distance":
+            ws = distances[closest_idx]
+            ws = ws**2
 
-        dist = AggrDist.create_test_instance()
-        params3 = {"distance": dist}
+            # Using epsilon ~= 0 to avoid division by zero
+            ws = 1 / (ws + np.finfo(float).eps)
+        elif self.weights == "uniform":
+            ws = np.repeat(1., self.n_neighbors)
+        else:
+            raise Exception(f"Invalid kNN weights: {self.weights}")
 
-        return [params1, params2, params3]
+        return closest_idx, ws

--- a/sktime/classification/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/classification/distance_based/tests/test_time_series_neighbors.py
@@ -1,15 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for KNeighborsTimeSeriesClassifier."""
-import numpy as np
-import pandas as pd
 import pytest
 
-from sktime.alignment.dtw_python import AlignerDTW
 from sktime.classification.distance_based._time_series_neighbors import (
     KNeighborsTimeSeriesClassifier,
 )
 from sktime.datasets import load_unit_test
-from sktime.utils.validation._dependencies import _check_estimator_deps
 
 distance_functions = [
     "euclidean",
@@ -77,59 +73,3 @@ def test_knn_bounding_matrix(distance_key):
         if pred[j] == y_test[j]:
             correct = correct + 1
     assert correct == expected_correct_window[distance_key]
-
-
-@pytest.mark.skipif(
-    not _check_estimator_deps(AlignerDTW, severity="none"),
-    reason="skip test if required soft dependencies not available",
-)
-def test_knn_with_aligner():
-    """Tests KNN classifer with alignment distance on unequal length data."""
-    from sktime.dists_kernels.compose_from_align import DistFromAligner
-    from sktime.utils._testing.hierarchical import _make_hierarchical
-
-    X = _make_hierarchical((3,), min_timepoints=5, max_timepoints=10, random_state=0)
-    y = np.array([0, 1, 1])
-
-    dtw_dist = DistFromAligner(AlignerDTW())
-    clf = KNeighborsTimeSeriesClassifier(distance=dtw_dist)
-
-    clf.fit(X, y)
-
-
-def test_knn_with_aggrdistance():
-    """Tests KNN classifer with alignment distance on unequal length data."""
-    from sktime.dists_kernels import AggrDist, ScipyDist
-    from sktime.utils._testing.hierarchical import _make_hierarchical
-
-    X = _make_hierarchical((3,), min_timepoints=5, max_timepoints=10, random_state=0)
-    y = np.array([0, 1, 1])
-
-    eucl_dist = ScipyDist()
-    aggr_dist = AggrDist(eucl_dist)
-    clf = KNeighborsTimeSeriesClassifier(distance=aggr_dist)
-
-    clf.fit(X, y)
-
-
-def test_knn_kneighbors():
-    """Tests kneighbors method and absence of bug #3798."""
-    from sktime.utils._testing.hierarchical import _make_hierarchical
-
-    Xtrain = _make_hierarchical(hierarchy_levels=(3,), n_columns=3)
-    Xtest = _make_hierarchical(hierarchy_levels=(5,), n_columns=3)
-
-    ytrain = pd.Series(["label_1", "label_2", "label_3"])
-
-    kntsc = KNeighborsTimeSeriesClassifier(n_neighbors=1)
-    kntsc.fit(Xtrain, ytrain)
-
-    ret = kntsc.kneighbors(Xtest)
-    assert isinstance(ret, tuple)
-    assert len(ret) == 2
-
-    dist, ind = ret
-    assert isinstance(dist, np.ndarray)
-    assert dist.shape == (5, 1)
-    assert isinstance(ind, np.ndarray)
-    assert ind.shape == (5, 1)

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -4,38 +4,25 @@
 This class is a KNN regressor which supports time series distance measures.
 The class has hardcoded string references to numba based distances in sktime.distances.
 It can also be used with callables, or sktime (pairwise transformer) estimators.
-
-This is a direct wrap or sklearn KNeighbors, with added functionality that allows
-time series distances to be passed, and the sktime time series regressor interface.
 """
 
-__author__ = ["fkiraly"]
+__author__ = ["TonyBagnall", "GuiArcencio"]
 __all__ = ["KNeighborsTimeSeriesRegressor"]
 
-from sklearn.neighbors import KNeighborsRegressor
+import numpy as np
 
-from sktime.distances import pairwise_distance
+from sktime.distances import distance_factory
 from sktime.regression.base import BaseRegressor
 
-# add new distance string codes here
-DISTANCES_SUPPORTED = [
-    "euclidean",
-    # Euclidean will default to the base class distance
-    "dtw",
-    "ddtw",
-    "wdtw",
-    "wddtw",
-    "lcss",
-    "edr",
-    "erp",
-    "msm",
+WEIGHTS_SUPPORTED = [
+    "uniform",
+    "distance"
 ]
-
 
 class KNeighborsTimeSeriesRegressor(BaseRegressor):
     """KNN Time Series Regressor.
 
-    An adapted version of the scikit-learn KNeighborsRegressor for time series data.
+    An adapted K-Neighbors Regressor for time series data.
 
     This class is a KNN regressor which supports time series distance measures.
     It has hardcoded string references to numba based distances in sktime.distances,
@@ -47,9 +34,6 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
     weights : string or callable function, optional. default = 'uniform'
         mechanism for weighting a vot
         one of: 'uniform', 'distance', or a callable function
-    algorithm : str, optional. default = 'brute'
-        search method for neighbours
-        one of {'auto’, 'ball_tree', 'kd_tree', 'brute'}
     distance : str or callable, optional. default ='dtw'
         distance measure between time series
         if str, must be one of the following strings:
@@ -66,17 +50,6 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         can be pairwise panel transformer inheriting from BasePairwiseTransformerPanel
     distance_params : dict, optional. default = None.
         dictionary for metric parameters , in case that distane is a str
-    distance_mtype : str, or list of str optional. default = None.
-        mtype that distance expects for X and X2, if a callable
-            only set this if distance is not BasePairwiseTransformerPanel descendant
-    leaf_size : int, default=30
-        Leaf size passed to BallTree or KDTree. This can affect the
-        speed of the construction and query, as well as the memory required to store
-        the tree. The optimal value depends on the nature of the problem.
-    n_jobs : int, default=None
-        The number of parallel jobs to run for neighbors search.
-        ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
-        ``-1`` means using all processors.
 
     Examples
     --------
@@ -92,80 +65,28 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
 
     _tags = {
         "capability:multivariate": True,
-        "capability:unequal_length": True,
-        "capability:missing_values": True,
-        "X_inner_mtype": ["pd-multiindex", "numpy3D"],
+        "X_inner_mtype": ["numpy3D"],
     }
 
     def __init__(
         self,
-        n_neighbors=1,
-        weights="uniform",
-        algorithm="brute",
         distance="dtw",
         distance_params=None,
-        distance_mtype=None,
-        leaf_size=30,
-        n_jobs=None,
+        n_neighbors=1,
+        weights="uniform",
     ):
-        self.n_neighbors = n_neighbors
-        self.algorithm = algorithm
         self.distance = distance
         self.distance_params = distance_params
-        self.distance_mtype = distance_mtype
-        self.leaf_size = leaf_size
-        self.n_jobs = n_jobs
-        # translate distance strings into distance callables
-        if isinstance(distance, str) and distance not in DISTANCES_SUPPORTED:
-            raise ValueError(
-                f"Unrecognised distance measure string: {distance}. "
-                f"Allowed values for string codes are: {DISTANCES_SUPPORTED}. "
-                "Alternatively, pass a callable distance measure into the constuctor."
-            )
+        self.n_neighbors = n_neighbors
 
-        self.knn_estimator_ = KNeighborsRegressor(
-            n_neighbors=n_neighbors,
-            algorithm=algorithm,
-            metric="precomputed",
-            metric_params=distance_params,
-            leaf_size=leaf_size,
-            n_jobs=n_jobs,
-        )
+        if weights not in WEIGHTS_SUPPORTED:
+            raise ValueError(
+                f"Unrecognised kNN weights: {weights}. "
+                f"Allowed values are: {WEIGHTS_SUPPORTED}. "
+            )
         self.weights = weights
 
         super(KNeighborsTimeSeriesRegressor, self).__init__()
-
-        # the distances in sktime.distances want numpy3D
-        #   otherwise all Panel formats are ok
-        if isinstance(self.distance, str):
-            self.set_tags(X_inner_mtype="numpy3D")
-            self.set_tags(**{"capability:unequal_length": False})
-            self.set_tags(**{"capability:missing_values": False})
-        elif distance_mtype is not None:
-            self.set_tags(X_inner_mtype=distance_mtype)
-
-        from sktime.dists_kernels import BasePairwiseTransformerPanel
-
-        # inherit capability tags from distance, if it is an estimator
-        if isinstance(distance, BasePairwiseTransformerPanel):
-            inherit_tags = [
-                "capability:missing_values",
-                "capability:unequal_length",
-                "capability:multivariate",
-            ]
-            self.clone_tags(distance, inherit_tags)
-
-    def _distance(self, X, X2):
-        """Compute distance - unified interface to str code and callable."""
-        distance = self.distance
-        distance_params = self.distance_params
-        if distance_params is None:
-            distance_params = {}
-
-        if isinstance(distance, str):
-            return pairwise_distance(X, X2, distance, **distance_params)
-        else:
-            return distance(X, X2)
 
     def _fit(self, X, y):
         """Fit the model using X as training data and y as target values.
@@ -176,54 +97,19 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         y : {array-like, sparse matrix}
             Target values of shape = [n_samples]
         """
-        # store full data as indexed X
-        self._X = X
+        if isinstance(self.distance, str):
+            if self.distance_params is None:
+                self.metric_ = distance_factory(X[0], X[0], metric=self.distance)
+            else:
+                self.metric_ = distance_factory(
+                    X[0], X[0], metric=self.distance, **self.distance_params
+                )
 
-        dist_mat = self._distance(X, X)
-
-        self.knn_estimator_.fit(dist_mat, y)
-
+        self.X_ = X
+        self.y_ = y
         return self
 
-    def kneighbors(self, X, n_neighbors=None, return_distance=True):
-        """Find the K-neighbors of a point.
-
-        Returns indices of and distances to the neighbors of each point.
-
-        Parameters
-        ----------
-        X : sktime-compatible data format, Panel or Series, with n_samples series
-        y : {array-like, sparse matrix}
-            Target values of shape = [n_samples]
-        n_neighbors : int
-            Number of neighbors to get (default is the value
-            passed to the constructor).
-        return_distance : boolean, optional. Defaults to True.
-            If False, distances will not be returned
-
-        Returns
-        -------
-        dist : array
-            Array representing the lengths to points, only present if
-            return_distance=True
-        ind : array
-            Indices of the nearest points in the population matrix.
-        """
-        self.check_is_fitted()
-
-        # boilerplate input checks for predict-like methods
-        X = self._check_convert_X_for_predict(X)
-
-        # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
-
-        neigh_ind = self.knn_estimator_.kneighbors(
-            dist_mat, n_neighbors=n_neighbors, return_distance=return_distance
-        )
-
-        return neigh_ind
-
-    def _predict(self, X):
+    def _predict(self, X) -> np.ndarray:
         """Predict the class labels for the provided data.
 
         Parameters
@@ -233,11 +119,55 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         Returns
         -------
         y : array of shape [n_samples] or [n_samples, n_outputs]
-            Class labels for each data sample.
+            Target values for each data sample.
         """
-        # self._X should be the stored _X
-        dist_mat = self._distance(X, self._X)
+        self.check_is_fitted()
 
-        y_pred = self.knn_estimator_.predict(dist_mat)
+        preds = np.zeros(X.shape[0])
+        for i in range(X.shape[0]):
+            idx, weights = self._kneighbors(X[i])
+            preds[i] = np.average(self.y_[idx], weights=weights)
 
-        return y_pred
+        return preds
+    
+    def _kneighbors(self, X):
+        """Find the K-neighbors of a point.
+
+        Returns indices and weights of each point.
+
+        Parameters
+        ----------
+        X : sktime-compatible data format, Panel or Series, with n_samples series
+
+        Returns
+        -------
+        ind : array
+            Indices of the nearest points in the population matrix.
+        ws : array
+            Array representing the weights of each neighbor.
+        """
+        
+        distances = np.array(
+            [self.metric_(X, self.X_[j]) for j in range(self.X_.shape[0])]
+        )
+
+        # Find indices of k nearest neighbors using partitioning:
+        # [0..k-1], [k], [k+1..n-1]
+        # They might not be ordered within themselves,
+        # but it is not necessary and partitioning is
+        # O(n) while sorting is O(nlogn)
+        closest_idx = np.argpartition(distances, self.n_neighbors)
+        closest_idx = closest_idx[: self.n_neighbors]
+
+        if self.weights == "distance":
+            ws = distances[closest_idx]
+            ws = ws**2
+
+            # Using epsilon ~= 0 to avoid division by zero
+            ws = 1 / (ws + np.finfo(float).eps)
+        elif self.weights == "uniform":
+            ws = np.repeat(1., self.n_neighbors)
+        else:
+            raise Exception(f"Invalid kNN weights: {self.weights}")
+
+        return closest_idx, ws

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -36,15 +36,13 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         distance measure between time series
         if str, must be one of the following strings:
             'euclidean', 'squared', 'dtw', 'ddtw', 'wdtw', 'wddtw',
-            'lcss', 'edr', 'erp', 'msm'
+            'lcss', 'edr', 'erp', 'msm', 'twe'
         this will substitute a hard-coded distance metric from sktime.distances
         When mpdist is used, the subsequence length (parameter m) must be set
             Example: knn_mpdist = KNeighborsTimeSeriesClassifier(
                                 metric='mpdist', metric_params={'m':30})
-        if callable, must be of signature (X: Panel, X2: Panel) -> np.ndarray
-            output must be mxn array if X is Panel of m Series, X2 of n Series
-            if distance_mtype is not set, must be able to take
-                X, X2 which are pd_multiindex and numpy3D mtype
+        if callable, must be of signature (X: np.ndarray, X2: np.ndarray) -> np.ndarray
+            output must be mxn array if X is array of m Series, X2 of n Series
         can be pairwise panel transformer inheriting from BasePairwiseTransformerPanel
     distance_params : dict, optional. default = None.
         dictionary for metric parameters , in case that distance is a str
@@ -55,7 +53,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
     >>> from sktime.regression.distance_based import KNeighborsTimeSeriesRegressor
     >>> X_train, y_train = load_unit_test(return_X_y=True, split="train")
     >>> X_test, y_test = load_unit_test(return_X_y=True, split="test")
-    >>> regressor = KNeighborsTimeSeriesRegressor()
+    >>> regressor = KNeighborsTimeSeriesRegressor(distance="euclidean")
     >>> regressor.fit(X_train, y_train)
     KNeighborsTimeSeriesRegressor(...)
     >>> y_pred = regressor.predict(X_test)

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -14,10 +14,8 @@ import numpy as np
 from sktime.distances import distance_factory
 from sktime.regression.base import BaseRegressor
 
-WEIGHTS_SUPPORTED = [
-    "uniform",
-    "distance"
-]
+WEIGHTS_SUPPORTED = ["uniform", "distance"]
+
 
 class KNeighborsTimeSeriesRegressor(BaseRegressor):
     """KNN Time Series Regressor.
@@ -129,7 +127,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
             preds[i] = np.average(self.y_[idx], weights=weights)
 
         return preds
-    
+
     def _kneighbors(self, X):
         """Find the K-neighbors of a point.
 
@@ -146,7 +144,6 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         ws : array
             Array representing the weights of each neighbor.
         """
-        
         distances = np.array(
             [self.metric_(X, self.X_[j]) for j in range(self.X_.shape[0])]
         )
@@ -166,7 +163,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
             # Using epsilon ~= 0 to avoid division by zero
             ws = 1 / (ws + np.finfo(float).eps)
         elif self.weights == "uniform":
-            ws = np.repeat(1., self.n_neighbors)
+            ws = np.repeat(1.0, self.n_neighbors)
         else:
             raise Exception(f"Invalid kNN weights: {self.weights}")
 

--- a/sktime/regression/distance_based/_time_series_neighbors.py
+++ b/sktime/regression/distance_based/_time_series_neighbors.py
@@ -49,7 +49,7 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
                 X, X2 which are pd_multiindex and numpy3D mtype
         can be pairwise panel transformer inheriting from BasePairwiseTransformerPanel
     distance_params : dict, optional. default = None.
-        dictionary for metric parameters , in case that distane is a str
+        dictionary for metric parameters , in case that distance is a str
 
     Examples
     --------
@@ -109,8 +109,8 @@ class KNeighborsTimeSeriesRegressor(BaseRegressor):
         self.y_ = y
         return self
 
-    def _predict(self, X) -> np.ndarray:
-        """Predict the class labels for the provided data.
+    def _predict(self, X):
+        """Predict the target values for the provided data.
 
         Parameters
         ----------

--- a/sktime/regression/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/regression/distance_based/tests/test_time_series_neighbors.py
@@ -1,20 +1,23 @@
 # -*- coding: utf-8 -*-
 """Tests for KNeighborsTimeSeriesRegressor."""
 import numpy as np
-import pandas as pd
 
 from sktime.regression.distance_based._time_series_neighbors import (
     KNeighborsTimeSeriesRegressor,
 )
 
+
 def test_knn_neighbors():
     """Tests kneighbors method."""
+
     from sklearn.datasets import make_regression
     from sklearn.model_selection import train_test_split
 
     X, y = make_regression(n_samples=100, n_features=32, random_state=42)
     X = X.reshape((X.shape[0], 1, X.shape[1]))
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.3, random_state=42
+    )
 
     model = KNeighborsTimeSeriesRegressor(n_neighbors=5, weights="distance")
     model.fit(X_train, y_train)

--- a/sktime/regression/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/regression/distance_based/tests/test_time_series_neighbors.py
@@ -7,25 +7,19 @@ from sktime.regression.distance_based._time_series_neighbors import (
     KNeighborsTimeSeriesRegressor,
 )
 
+def test_knn_neighbors():
+    """Tests kneighbors method."""
+    from sklearn.datasets import make_regression
+    from sklearn.model_selection import train_test_split
 
-def test_knn_kneighbors():
-    """Tests kneighbors method and absence of bug #3798."""
-    from sktime.utils._testing.hierarchical import _make_hierarchical
+    X, y = make_regression(n_samples=100, n_features=32, random_state=42)
+    X = X.reshape((X.shape[0], 1, X.shape[1]))
+    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
 
-    Xtrain = _make_hierarchical(hierarchy_levels=(3,), n_columns=3)
-    Xtest = _make_hierarchical(hierarchy_levels=(5,), n_columns=3)
+    model = KNeighborsTimeSeriesRegressor(n_neighbors=5, weights="distance")
+    model.fit(X_train, y_train)
 
-    ytrain = pd.Series([1, 1.5, 2])
+    y_pred = model.predict(X_test)
 
-    kntsc = KNeighborsTimeSeriesRegressor(n_neighbors=1)
-    kntsc.fit(Xtrain, ytrain)
-
-    ret = kntsc.kneighbors(Xtest)
-    assert isinstance(ret, tuple)
-    assert len(ret) == 2
-
-    dist, ind = ret
-    assert isinstance(dist, np.ndarray)
-    assert dist.shape == (5, 1)
-    assert isinstance(ind, np.ndarray)
-    assert ind.shape == (5, 1)
+    assert isinstance(y_pred, np.ndarray)
+    assert y_pred.shape == y_test.shape

--- a/sktime/regression/distance_based/tests/test_time_series_neighbors.py
+++ b/sktime/regression/distance_based/tests/test_time_series_neighbors.py
@@ -13,16 +13,14 @@ def test_knn_neighbors():
     from sklearn.datasets import make_regression
     from sklearn.model_selection import train_test_split
 
-    X, y = make_regression(n_samples=100, n_features=32, random_state=42)
+    X, y = make_regression(n_samples=9, n_features=3, random_state=42)
     X = X.reshape((X.shape[0], 1, X.shape[1]))
-    X_train, X_test, y_train, y_test = train_test_split(
-        X, y, test_size=0.3, random_state=42
-    )
+    X_train, X_test, y_train, _ = train_test_split(X, y, test_size=3, random_state=42)
 
     model = KNeighborsTimeSeriesRegressor(n_neighbors=5, weights="distance")
     model.fit(X_train, y_train)
 
     y_pred = model.predict(X_test)
+    y_pred_expected = np.array([-216.06541863, -4.54133078, -324.7624233])
 
-    assert isinstance(y_pred, np.ndarray)
-    assert y_pred.shape == y_test.shape
+    assert np.abs(y_pred - y_pred_expected).max() < 1e-6


### PR DESCRIPTION
#### Reference Issues/PRs
- Fixes #39.

#### What does this implement/fix? Explain your changes.
- Reimplemented both `KNeighborsTimeSeriesClassifier` and `KNeighborsTimeSeriesRegressor` in order to fix memory leaks and replace hard coded "distances" string list.
- Removed computation of distance matrices in `fit` (which was useless in any case) and `predict`, as well as `sklearn`'s `KNeighbors` instances contained within the models. The k-Neighbors algorithm is now implemented here.
- Nearest neighbors are found by `np.argpartition`ing the distance vector into `[0..k-1]`, `[k]`, `[k+1..]`, which is $O(n)$ as opposed to the $O(n \log n)$ in sorting.
- Distance metrics are now generated by `distance_factory`, uncoupling the selection of possible metrics from the model.

#### What should a reviewer concentrate their feedback on?

- [ ] Documentation for the new implementations might be lacking or inconsistent.
- [ ] Other mtypes could be added for unequal-length support.
- [ ] `n_jobs` is a parameter for the new classifier for compatibility purposes only. There is no parallelism implementation yet.

The following graphs show the results of current and new implementation benchmarks. The experiments were made on a regression dataset which consists of univariate time series of length 365. At each sample size, data was split between train and test in 70% - 30% proportions, respectively. The distance was always set to 'euclidean'.

![euclidean](https://user-images.githubusercontent.com/47733489/219441979-2781d912-ca7a-428d-b92e-bdb3af7e6383.svg)

More benchmarks are underway, one using distance='dtw' and two others fixing train size and varying test size, and vice-versa.

#### Did you add any tests for the change?

Some tests were removed and/or changed due to being implementation-specific.

#### PR checklist

##### For all contributions
- [x] I've added myself to the [list of contributors](https://github.com/sktime/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/sktime/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.
