### PR TITLE
[ENH] Speedup EAgglo by factor 5-10x

### DIFF
--- a/sktime/annotation/eagglo.py
+++ b/sktime/annotation/eagglo.py
@@ -465,19 +465,6 @@ def mean_diff_penalty(x: pd.DataFrame) -> float:
     return np.mean(np.diff(np.sort(x)))
 
 
-# @njit(fastmath=True, cache=True)
-# def get_distance_matrix(X, Y, alpha) -> float:
-#    """Calculate cluster distance."""
-#    dist = euclidean_distance(X, Y) # euclidean_matrix_to_matrix(X, Y)
-#    return np.power(dist, alpha).mean()
-
-
-# @njit(nopython=True, fastmath=True)
-# def get_distance_single(X, Y, alpha) -> float:
-#    dist = euclidean_distance(X, Y)
-#    return np.power(dist, alpha)  # .mean()
-
-
 @njit(fastmath=True, cache=True)
 def get_distance_matrix(X, Y, alpha) -> float:
     """Calculate cluster distance."""

--- a/sktime/annotation/eagglo.py
+++ b/sktime/annotation/eagglo.py
@@ -242,7 +242,7 @@ class EAgglo(BaseTransformer):
         # array of between-within distances
         self.distances = np.empty((2 * self.n_cluster, 2 * self.n_cluster))
 
-        # if there is no initial grouping...
+        # if there is an initial grouping...
         if self.member is not None:
             grouped = X.copy().set_index(self._member).groupby(level=0)
             within = grouped.apply(
@@ -260,7 +260,7 @@ class EAgglo(BaseTransformer):
                     - within[i]
                     - within
                 )
-        # else...
+        # else (no initial groupings)...
         else:
             X_num = X.to_numpy()
             for i in range(len(X)):

--- a/sktime/annotation/eagglo.py
+++ b/sktime/annotation/eagglo.py
@@ -465,6 +465,19 @@ def mean_diff_penalty(x: pd.DataFrame) -> float:
     return np.mean(np.diff(np.sort(x)))
 
 
+# @njit(fastmath=True, cache=True)
+# def get_distance_matrix(X, Y, alpha) -> float:
+#    """Calculate cluster distance."""
+#    dist = euclidean_distance(X, Y) # euclidean_matrix_to_matrix(X, Y)
+#    return np.power(dist, alpha).mean()
+
+
+# @njit(nopython=True, fastmath=True)
+# def get_distance_single(X, Y, alpha) -> float:
+#    dist = euclidean_distance(X, Y)
+#    return np.power(dist, alpha)  # .mean()
+
+
 @njit(fastmath=True, cache=True)
 def get_distance_matrix(X, Y, alpha) -> float:
     """Calculate cluster distance."""
@@ -493,8 +506,3 @@ def euclidean_matrix_to_matrix(a, b):
 def euclidean(u, v):
     buf = u - v
     return np.sqrt(buf @ buf)
-
-
-# def get_distance_scipy(X: pd.DataFrame, Y: pd.DataFrame, alpha: float) -> float:
-#    """Calculate within/between cluster distance using scipy."""
-#    return np.power(cdist(X, Y, "euclidean"), alpha).mean()

--- a/sktime/annotation/tests/test_eagglo.py
+++ b/sktime/annotation/tests/test_eagglo.py
@@ -136,6 +136,6 @@ def test_custom_penalty():
 #     from sktime.datasets import load_gun_point_segmentation
 #     ts, period_size, cps = load_gun_point_segmentation()
 #
-#     # compute a ClaSP segmentation
+#     # compute a segmentation
 #     model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
 #     fitted_model = model._fit(pd.DataFrame(ts[:2000]))

--- a/sktime/annotation/tests/test_eagglo.py
+++ b/sktime/annotation/tests/test_eagglo.py
@@ -139,7 +139,7 @@ def test_eagglo_large():
 
     # compute a ClaSP segmentation
     model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
-    fitted_model = model._fit(pd.DataFrame(ts[:500]))
+    fitted_model = model._fit(pd.DataFrame(ts[:2000]))
 
     _ = fitted_model.cluster_
     _ = fitted_model.gof_

--- a/sktime/annotation/tests/test_eagglo.py
+++ b/sktime/annotation/tests/test_eagglo.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 
 from sktime.annotation.eagglo import EAgglo
-from sktime.datasets import load_gun_point_segmentation
 
 
 def test_fit_default_params_univariate():
@@ -129,20 +128,14 @@ def test_custom_penalty():
     assert np.allclose(fit_actual, fit_expected)
 
 
-def test_eagglo_large():
-    """Tests EAgglo with a large dataset.
-
-    Check if the predicted segmentation matches.
-    """
-    # load the test dataset
-    ts, period_size, cps = load_gun_point_segmentation()
-
-    # compute a ClaSP segmentation
-    model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
-    fitted_model = model._fit(pd.DataFrame(ts[:2000]))
-
-    _ = fitted_model.cluster_
-    _ = fitted_model.gof_
-
-    # print(cluster_actual)
-    # print(fit_actual)
+# def test_eagglo_large():
+#     """Tests EAgglo with a large dataset.
+#     Check if the predicted segmentation matches.
+#     """
+#     # load the test dataset
+#     from sktime.datasets import load_gun_point_segmentation
+#     ts, period_size, cps = load_gun_point_segmentation()
+#
+#     # compute a ClaSP segmentation
+#     model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
+#     fitted_model = model._fit(pd.DataFrame(ts[:2000]))

--- a/sktime/annotation/tests/test_eagglo.py
+++ b/sktime/annotation/tests/test_eagglo.py
@@ -126,16 +126,3 @@ def test_custom_penalty():
 
     assert np.allclose(cluster_actual, cluster_expected)
     assert np.allclose(fit_actual, fit_expected)
-
-
-# def test_eagglo_large():
-#     """Tests EAgglo with a large dataset.
-#     Check if the predicted segmentation matches.
-#     """
-#     # load the test dataset
-#     from sktime.datasets import load_gun_point_segmentation
-#     ts, period_size, cps = load_gun_point_segmentation()
-#
-#     # compute a segmentation
-#     model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
-#     fitted_model = model._fit(pd.DataFrame(ts[:2000]))

--- a/sktime/annotation/tests/test_eagglo.py
+++ b/sktime/annotation/tests/test_eagglo.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 
 from sktime.annotation.eagglo import EAgglo
+from sktime.datasets import load_gun_point_segmentation
 
 
 def test_fit_default_params_univariate():
@@ -126,3 +127,22 @@ def test_custom_penalty():
 
     assert np.allclose(cluster_actual, cluster_expected)
     assert np.allclose(fit_actual, fit_expected)
+
+
+def test_eagglo_large():
+    """Tests EAgglo with a large dataset.
+
+    Check if the predicted segmentation matches.
+    """
+    # load the test dataset
+    ts, period_size, cps = load_gun_point_segmentation()
+
+    # compute a ClaSP segmentation
+    model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
+    fitted_model = model._fit(pd.DataFrame(ts[:500]))
+
+    _ = fitted_model.cluster_
+    _ = fitted_model.gof_
+
+    # print(cluster_actual)
+    # print(fit_actual)


### PR DESCRIPTION
### EAgglo
This PR improves the runtime of EAgglo by a factor of 5-10, by use of:

- NUMBA
- Reimplement Euclidean Distance (instead of scipy cdist)
- Reworked initial distance computations, if `self._member is None` (no groupings + Pandas needed)

### Experiments:

```python
from sktime.datasets import load_gun_point_segmentation
ts, period_size, cps = load_gun_point_segmentation()

# compute a segmentation
model = EAgglo(penalty=lambda x: np.mean(np.diff(np.sort(ts))))
fitted_model = model._fit(pd.DataFrame(ts[:2000]))
```

### Before refactor: 120 seconds
### After:  12 seconds